### PR TITLE
add Gtk::Container foreach and forall methods

### DIFF
--- a/gtk3/ext/gtk3/depend
+++ b/gtk3/ext/gtk3/depend
@@ -1,0 +1,6 @@
+install: install-pc
+install-pc:
+	if test -n "$(pkgconfigdir)"; then			\
+	  $(MAKEDIRS) $(pkgconfigdir);				\
+	  $(INSTALL_DATA) ruby-gtk3.pc $(pkgconfigdir);		\
+	fi

--- a/gtk3/ext/gtk3/extconf.rb
+++ b/gtk3/ext/gtk3/extconf.rb
@@ -1,0 +1,77 @@
+#!/usr/bin/env ruby
+#
+# Copyright (C) 2015  Ruby-GNOME2 Project Team
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+
+require "pathname"
+
+base_dir = Pathname(__FILE__).dirname.parent.parent.expand_path
+top_dir = base_dir.parent
+top_build_dir = Pathname(".").parent.parent.parent.expand_path
+
+mkmf_gnome2_dir = top_dir + "glib2" + "lib"
+version_suffix = ""
+unless mkmf_gnome2_dir.exist?
+  if /(-\d+\.\d+\.\d+)\z/ =~ base_dir.basename.to_s
+    version_suffix = $1
+    mkmf_gnome2_dir = top_dir + "glib2#{version_suffix}" + "lib"
+  end
+end
+
+$LOAD_PATH.unshift(mkmf_gnome2_dir.to_s)
+
+module_name = "gtk3"
+package_id = "gtk+-3.0"
+
+require "mkmf-gnome2"
+
+["glib2", "gobject-introspection", "cairo-gobject", "atk", "pango", "gdk_pixbuf2", "gdk3"].each do |package|
+  directory = "#{package}#{version_suffix}"
+  build_base_path = "#{directory}/tmp/#{RUBY_PLATFORM}"
+  package_library_name = package.gsub(/-/, "_")
+  build_dir = "#{build_base_path}/#{package_library_name}/#{RUBY_VERSION}"
+  add_depend_package(package, "#{directory}/ext/#{package}",
+                     top_dir.to_s,
+                     :top_build_dir => top_build_dir.to_s,
+                     :target_build_dir => build_dir)
+end
+
+setup_windows(module_name, base_dir)
+
+unless required_pkg_config_package(package_id,
+                                   :debian => "libgtk-3-dev",
+                                   :redhat => "gtk3-devel",
+                                   :homebrew => "gtk+3",
+                                   :macports => "gtk3")
+  exit(false)
+end
+
+unless PKGConfig.have_package("gobject-introspection-1.0")
+  exit(false)
+end
+
+create_pkg_config_file("Ruby/GTK3", package_id)
+
+$defs << "-DRUBY_GTK3_COMPILATION"
+create_makefile(module_name)
+
+pkg_config_dir = with_config("pkg-config-dir")
+if pkg_config_dir.is_a?(String)
+  File.open("Makefile", "ab") do |makefile|
+    makefile.puts
+    makefile.puts("pkgconfigdir=#{pkg_config_dir}")
+  end
+end

--- a/gtk3/ext/gtk3/rb-gtk3-container.c
+++ b/gtk3/ext/gtk3/rb-gtk3-container.c
@@ -1,0 +1,75 @@
+/* -*- c-file-style: "ruby"; indent-tabs-mode: nil -*- */
+/*
+ *  Copyright (C) 2015  Ruby-GNOME2 Project Team
+ *
+ *  This library is free software; you can redistribute it and/or
+ *  modify it under the terms of the GNU Lesser General Public
+ *  License as published by the Free Software Foundation; either
+ *  version 2.1 of the License, or (at your option) any later version.
+ *
+ *  This library is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *  Lesser General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Lesser General Public
+ *  License along with this library; if not, write to the Free Software
+ *  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+ *  MA  02110-1301  USA
+ */
+
+#include "rb-gtk3.h"
+#include "rb-gtk3-conversions.h"
+
+#define RG_TARGET_NAMESPACE mContainer
+
+#define RVAL2GTKCONTAINER(o)               (GTK_CONTAINER(RVAL2GOBJ(o)))
+#define _SELF(self) (RVAL2GTKCONTAINER(self))
+
+ID id_call;
+
+static void
+exec_callback(GtkWidget *widget, gpointer proc)
+{
+    rb_funcall((VALUE)proc, id_call, 1, GOBJ2RVAL(widget));
+}
+
+static VALUE
+rg_foreach(int argc, VALUE *argv, VALUE self)
+{
+    VALUE callback;
+
+    rb_scan_args(argc, argv, "01", &callback);
+    if (NIL_P(callback)) {
+        callback = rb_block_proc();
+    }
+    gtk_container_foreach(_SELF(self), exec_callback, (gpointer)callback);
+    return self;
+}
+
+static VALUE
+rg_forall(int argc, VALUE *argv, VALUE self)
+{
+    VALUE callback;
+
+    rb_scan_args(argc, argv, "01", &callback);
+    if (NIL_P(callback)) {
+        callback = rb_block_proc();
+    }
+    gtk_container_forall(_SELF(self), exec_callback, (gpointer)callback);
+    return self;
+}
+
+
+void
+rb_gtk3_init_container(VALUE mGtk)
+{
+    VALUE RG_TARGET_NAMESPACE;
+    id_call = rb_intern("call");
+    /* Do not use RG_DEF_CLASS here, because the Gtk::Container class
+     * is already created by the gi loader. */
+    RG_TARGET_NAMESPACE = rbgobj_gtype_to_ruby_class(GTK_TYPE_CONTAINER);
+
+    RG_DEF_METHOD(foreach, -1);
+    RG_DEF_METHOD(forall, -1);
+}

--- a/gtk3/ext/gtk3/rb-gtk3-conversions.h
+++ b/gtk3/ext/gtk3/rb-gtk3-conversions.h
@@ -1,0 +1,34 @@
+/* -*- c-file-style: "ruby"; indent-tabs-mode: nil -*- */
+/*
+ *  Copyright (C) 2008-2015  Ruby-GNOME2 Project Team
+ *
+ *  This library is free software; you can redistribute it and/or
+ *  modify it under the terms of the GNU Lesser General Public
+ *  License as published by the Free Software Foundation; either
+ *  version 2.1 of the License, or (at your option) any later version.
+ *
+ *  This library is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *  Lesser General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Lesser General Public
+ *  License along with this library; if not, write to the Free Software
+ *  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+ *  MA  02110-1301  USA
+ */
+
+#ifndef __RB_GTK3_CONVERSIONS_H__
+#define __RB_GTK3_CONVERSIONS_H__
+
+#define RVAL2GTKCONTAINER(o)               (GTK_CONTAINER(RVAL2GOBJ(o)))
+
+#endif /* __RB_GTK3_CONVERSIONS_H__ */
+
+
+
+
+
+
+
+

--- a/gtk3/ext/gtk3/rb-gtk3.c
+++ b/gtk3/ext/gtk3/rb-gtk3.c
@@ -1,0 +1,32 @@
+/* -*- c-file-style: "ruby"; indent-tabs-mode: nil -*- */
+/*
+ *  Copyright (C) 2015  Ruby-GNOME2 Project Team
+ *
+ *  This library is free software; you can redistribute it and/or
+ *  modify it under the terms of the GNU Lesser General Public
+ *  License as published by the Free Software Foundation; either
+ *  version 2.1 of the License, or (at your option) any later version.
+ *
+ *  This library is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *  Lesser General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Lesser General Public
+ *  License along with this library; if not, write to the Free Software
+ *  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+ *  MA  02110-1301  USA
+ */
+
+#include "rb-gtk3.h"
+
+#define RG_TARGET_NAMESPACE rb_mGio
+
+void
+Init_gtk3 (void)
+{
+    VALUE RG_TARGET_NAMESPACE;
+
+    RG_TARGET_NAMESPACE = rb_define_module("Gtk");
+    rb_gtk3_init_container(RG_TARGET_NAMESPACE);
+}

--- a/gtk3/ext/gtk3/rb-gtk3.h
+++ b/gtk3/ext/gtk3/rb-gtk3.h
@@ -1,0 +1,26 @@
+/* -*- c-file-style: "ruby"; indent-tabs-mode: nil -*- */
+/*
+ *  Copyright (C) 2015  Ruby-GNOME2 Project Team
+ *
+ *  This library is free software; you can redistribute it and/or
+ *  modify it under the terms of the GNU Lesser General Public
+ *  License as published by the Free Software Foundation; either
+ *  version 2.1 of the License, or (at your option) any later version.
+ *
+ *  This library is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *  Lesser General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Lesser General Public
+ *  License along with this library; if not, write to the Free Software
+ *  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+ *  MA  02110-1301  USA
+ */
+
+#include <gtk/gtk.h>
+
+#include <rb-gobject-introspection.h>
+
+extern void Init_gtk3 (void);
+G_GNUC_INTERNAL extern void rb_gtk3_init_container (VALUE rb_mGtk);

--- a/gtk3/lib/gtk3/loader.rb
+++ b/gtk3/lib/gtk3/loader.rb
@@ -28,6 +28,15 @@ module Gtk
       setup_pending_constants
     end
 
+    def require_extension
+      begin
+        major, minor, _ = RUBY_VERSION.split(/\./)
+        require "#{major}.#{minor}/gtk3.so"
+      rescue LoadError
+        require "gtk3.so"
+      end
+    end
+
     def call_init_function(repository, namespace)
       init_check = repository.find(namespace, "init_check")
       arguments = [
@@ -49,6 +58,7 @@ module Gtk
 
     def post_load(repository, namespace)
       apply_pending_constants
+      require_extension
       require_libraries
     end
 


### PR DESCRIPTION
The foreach and forall methods do not have the same names like the ones in the gtk-no-gi branch (each and each_forall), but they are direct mappings to the original gtk+ methods, which I think is in the spirit of the gi bindings. Maybe additional aliases should be created.