### PR TITLE
finish aboutdialog2.rb, update copyright version check for textbuffer_serialize.rb

### DIFF
--- a/gtk3/sample/misc/aboutdialog2.rb
+++ b/gtk3/sample/misc/aboutdialog2.rb
@@ -12,15 +12,6 @@ unless Gtk::Version.or_later?(3, 4, 2)
   exit
 end
 
-Gtk::AboutDialog.set_email_hook {|about, link|
-  p "email_hook"
-  p link
-}
-Gtk::AboutDialog.set_url_hook {|about, link|
-  p "url_hook"
-  p link
-}
-
 Gtk::AboutDialog.show(nil,
 		      "artists" => ["Artist 1 <no1@foo.bar.com>", "Artist 2 <no2@foo.bar.com>"],
 		      "authors" => ["Author 1 <no1@foo.bar.com>", "Author 2 <no2@foo.bar.com>"],

--- a/gtk3/sample/misc/textbuffer_serialize.rb
+++ b/gtk3/sample/misc/textbuffer_serialize.rb
@@ -2,21 +2,18 @@
 =begin
   textbuffer_serialize.rb - Ruby/GTK sample script.
 
-  Copyright (c) 2006 Ruby-GNOME2 Project Team 
+  Copyright (c) 2005-2015 Ruby-GNOME2 Project Team
   This program is licenced under the same licence as Ruby-GNOME2.
-
-  $Id: textbuffer_serialize.rb,v 1.1 2006/11/23 08:39:13 mutoh Exp $
 =end
 
-require 'gtk3'
+require "gtk3"
 
-if str = Gtk.check_version(2, 10, 0)
-  puts "This sample requires GTK+ 2.10.0 or later"
-  puts str
+unless Gtk::Version.or_later?(3, 4, 2)
+  puts "This sample requires GTK+ 3.4.2 or later: #{Gtk::Version::STRING}"
   exit
 end
 
-current_folder = ENV['HOME'] || "."
+current_folder = ENV["HOME"] || "."
 file_name = "serialized.dat"
 
 textview = Gtk::TextView.new


### PR DESCRIPTION
For aboutdialog2.rb I had have to remove the parts related to the email/url hook. Those methods were deprecated class methods. In order to update those parts I would have to use signal_connect which is an instance method so I would have to complicated the example.

 