### PR TITLE
gtk3: use 1-12 as a range of calendar month

### DIFF
--- a/gtk3/lib/gtk3/calendar.rb
+++ b/gtk3/lib/gtk3/calendar.rb
@@ -1,0 +1,24 @@
+# Copyright (C) 2015  Ruby-GNOME2 Project Team
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+
+module Gtk
+  class Calendar
+    alias_method :select_month_raw, :select_month
+    def select_month(month, year)
+      select_month_raw(month - 1, year)
+    end
+  end
+end

--- a/gtk3/lib/gtk3/loader.rb
+++ b/gtk3/lib/gtk3/loader.rb
@@ -74,6 +74,7 @@ module Gtk
       require "gtk3/button"
       require "gtk3/border"
       require "gtk3/builder"
+      require "gtk3/calendar"
       require "gtk3/color-chooser-dialog"
       require "gtk3/container"
       require "gtk3/css-provider"


### PR DESCRIPTION
GTK+ 2 and GTK+ 3 are use 0-11 as a range of calendar month.
But Ruby/GTK2 is uses 1-12 as a range of calendar month. I
think we should use 1-12 as a range of calendar month.

What do you think?

See: https://github.com/ruby-gnome2/ruby-gnome2/blob/master/gtk2/ext/gtk2/rbgtkcalendar.c#L41