### PR TITLE
handle initialize with entry for Gtk::ComboBoxText

### DIFF
--- a/gtk3/lib/gtk3/combo-box-text.rb
+++ b/gtk3/lib/gtk3/combo-box-text.rb
@@ -1,0 +1,30 @@
+# Copyright (C) 2015  Ruby-GNOME2 Project Team
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+
+module Gtk
+  class ComboBoxText
+    alias_method :initialize_raw, :initialize
+    def initialize(options={})
+      entry = options[:entry]
+
+      if entry
+        initialize_new_with_entry
+      else
+        initialize_new
+      end
+    end
+  end
+end

--- a/gtk3/lib/gtk3/loader.rb
+++ b/gtk3/lib/gtk3/loader.rb
@@ -77,6 +77,7 @@ module Gtk
       require "gtk3/calendar"
       require "gtk3/color-chooser-dialog"
       require "gtk3/combo-box"
+      require "gtk3/combo-box-text"
       require "gtk3/container"
       require "gtk3/css-provider"
       require "gtk3/dialog"

--- a/gtk3/test/test_gtk_combo_box_text.rb
+++ b/gtk3/test/test_gtk_combo_box_text.rb
@@ -1,0 +1,38 @@
+# Copyright (C) 2015  Ruby-GNOME2 Project Team
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+
+class TestGtkComboBoxText < Test::Unit::TestCase
+  include GtkTestUtils
+
+  sub_test_case(".new") do
+    sub_test_case(":entry => true") do
+      test "no others" do
+        combo_box_text = Gtk::ComboBoxText.new(:entry => true)
+        assert do
+          combo_box_text.has_entry?
+        end
+      end
+    end
+    sub_test_case("no :entry") do
+      test "no others" do
+        combo_box_text = Gtk::ComboBox.new
+        assert do
+          not combo_box_text.has_entry?
+        end
+      end
+    end
+  end
+end

--- a/gtk3/test/test_gtk_combo_box_text.rb
+++ b/gtk3/test/test_gtk_combo_box_text.rb
@@ -18,20 +18,16 @@ class TestGtkComboBoxText < Test::Unit::TestCase
   include GtkTestUtils
 
   sub_test_case(".new") do
-    sub_test_case(":entry => true") do
-      test "no others" do
-        combo_box_text = Gtk::ComboBoxText.new(:entry => true)
-        assert do
-          combo_box_text.has_entry?
-        end
+    test ":entry => true" do
+      combo_box_text = Gtk::ComboBoxText.new(:entry => true)
+      assert do
+        combo_box_text.has_entry?
       end
     end
-    sub_test_case("no :entry") do
-      test "no others" do
-        combo_box_text = Gtk::ComboBoxText.new
-        assert do
-          not combo_box_text.has_entry?
-        end
+    test ":entry => false" do
+      combo_box_text = Gtk::ComboBoxText.new
+      assert do
+        not combo_box_text.has_entry?
       end
     end
   end

--- a/gtk3/test/test_gtk_combo_box_text.rb
+++ b/gtk3/test/test_gtk_combo_box_text.rb
@@ -28,7 +28,7 @@ class TestGtkComboBoxText < Test::Unit::TestCase
     end
     sub_test_case("no :entry") do
       test "no others" do
-        combo_box_text = Gtk::ComboBox.new
+        combo_box_text = Gtk::ComboBoxText.new
         assert do
           not combo_box_text.has_entry?
         end


### PR DESCRIPTION
Allow user to create a Gtk::ComboBoxText with entry using :entry => true