### PR TITLE
Gtk::ColorSelectionDialog with hash arguments

### DIFF
--- a/gtk3/lib/gtk3/color-selection-dialog.rb
+++ b/gtk3/lib/gtk3/color-selection-dialog.rb
@@ -1,0 +1,26 @@
+# Copyright (C) 2015  Ruby-GNOME2 Project Team
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+
+module Gtk
+  class ColorSelectionDialog
+    alias_method :initialize_raw, :initialize
+    def initialize(options={})
+      title = options[:title] || ""
+      
+      initialize_raw(title)
+    end
+  end
+end

--- a/gtk3/lib/gtk3/loader.rb
+++ b/gtk3/lib/gtk3/loader.rb
@@ -77,6 +77,7 @@ module Gtk
       require "gtk3/calendar"
       require "gtk3/cell-layout"
       require "gtk3/color-chooser-dialog"
+      require "gtk3/color-selection-dialog"
       require "gtk3/combo-box"
       require "gtk3/combo-box-text"
       require "gtk3/container"

--- a/gtk3/test/test_gtk_color_selection_dialog.rb
+++ b/gtk3/test/test_gtk_color_selection_dialog.rb
@@ -1,0 +1,31 @@
+# Copyright (C) 2015  Ruby-GNOME2 Project Team
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+
+class TestGtkColorSelectionDialog < Test::Unit::TestCase
+  include GtkTestUtils
+
+  sub_test_case ".new" do
+    test "no argument" do
+      dialog = Gtk::ColorSelectionDialog.new
+      assert_equal("", dialog.title)
+    end
+
+    test "title" do
+      dialog = Gtk::ColorSelectionDialog.new(:title => "title")
+      assert_equal("title", dialog.title)
+    end
+  end
+end


### PR DESCRIPTION
I had had to add an empty string if no title was provided otherwise the test complains with:

    TypeError: no implicit conversion of nil into String