### PR TITLE
Gtk::FontChooserDialog with hash arguments

### DIFF
--- a/gtk3/lib/gtk3/font-chooser-dialog.rb
+++ b/gtk3/lib/gtk3/font-chooser-dialog.rb
@@ -1,0 +1,27 @@
+# Copyright (C) 2015  Ruby-GNOME2 Project Team
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+
+module Gtk
+  class FontChooserDialog
+    alias_method :initialize_raw, :initialize
+    def initialize(options={})
+      title = options[:title]
+      parent = options[:parent]
+
+      initialize_raw(title, parent)
+    end
+  end
+end

--- a/gtk3/lib/gtk3/loader.rb
+++ b/gtk3/lib/gtk3/loader.rb
@@ -83,6 +83,7 @@ module Gtk
       require "gtk3/css-provider"
       require "gtk3/dialog"
       require "gtk3/file-chooser-dialog"
+      require "gtk3/font-chooser-dialog"
       require "gtk3/icon-theme"
       require "gtk3/image"
       require "gtk3/label"

--- a/gtk3/test/test_gtk_font_chooser_dialog.rb
+++ b/gtk3/test/test_gtk_font_chooser_dialog.rb
@@ -1,0 +1,37 @@
+# Copyright (C) 2015  Ruby-GNOME2 Project Team
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+
+class TestGtkFontChooserDialog < Test::Unit::TestCase
+  include GtkTestUtils
+
+  sub_test_case ".new" do
+    test "no argument" do
+      dialog = Gtk::FontChooserDialog.new
+      assert_equal("", dialog.title)
+    end
+
+    test "title" do
+      dialog = Gtk::FontChooserDialog.new(:title => "title")
+      assert_equal("title", dialog.title)
+    end
+
+    test "parent" do
+      parent = Gtk::Window.new
+      dialog = Gtk::FontChooserDialog.new(:parent => parent)
+      assert_equal(parent, dialog.transient_for)
+    end
+  end
+end


### PR DESCRIPTION
In order to be consistant with the other dialogs