### PR TITLE
gtk3: ensure #title returns empty string if empty title option given

### DIFF
--- a/gtk3/lib/gtk3/color-chooser-dialog.rb
+++ b/gtk3/lib/gtk3/color-chooser-dialog.rb
@@ -18,7 +18,7 @@ module Gtk
   class ColorChooserDialog
     alias_method :initialize_raw, :initialize
     def initialize(options={})
-      title = options[:title]
+      title = options[:title] || ""
       parent = options[:parent]
 
       initialize_raw(title, parent)


### PR DESCRIPTION
How about this one?

Because Travis CI says:

```log
================================================================================

Failure: test: no argument(TestGtkColorChooserDialog::.new)
/home/travis/build/ruby-gnome2/ruby-gnome2/gtk3/test/test_gtk_color_chooser_dialog.rb:23:in
`block (2 levels) in <class:TestGtkColorChooserDialog>'
20: sub_test_case ".new" do
21: test "no argument" do
22: dialog = Gtk::ColorChooserDialog.new
=> 23: assert_equal("", dialog.title)
24: end
25:
26: test "title" do
<""> expected but was
<nil>
================================================================================
```