### PR TITLE
update to new api and update copyright linkbutton.rb

### DIFF
--- a/gtk3/sample/misc/linkbutton.rb
+++ b/gtk3/sample/misc/linkbutton.rb
@@ -2,18 +2,16 @@
 =begin
   linkbutton.rb - Gtk::LinkButton sample.
 
-  Copyright (c) 2006 Ruby-GNOME2 Project Team
+  Copyright (c) 2006-2015 Ruby-GNOME2 Project Team
   This program is licenced under the same licence as Ruby-GNOME2.
-
-  $Id: linkbutton.rb,v 1.1 2006/10/21 16:58:00 mutoh Exp $
 =end
 
-require 'gtk3'
+require "gtk3"
 
 window = Gtk::Window.new("Gtk::LinkButton sample")
 window.signal_connect("destroy"){Gtk.main_quit}
 
-vbox = Gtk::VBox.new
+vbox = Gtk::Box.new(:vertical,0)
 
 # URI only
 button1 = Gtk::LinkButton.new("http://ruby-gnome2.sourceforge.jp/")
@@ -28,11 +26,6 @@ button2 = Gtk::LinkButton.new("http://ruby-gnome2.sourceforge.jp/",
 button2.signal_connect("clicked") do
   puts button2.uri
 end
-
-# Global setting instead of using clicked signals.
-Gtk::LinkButton.set_uri_hook {|button, link|
-  puts "set_uri_hook: " + link
-}
 
 vbox.pack_start(button2)
 


### PR DESCRIPTION
I had to remove the part Gtk::LinkButton.set_uri_hook because it was deprecated.