### PR TITLE
gtk3 container: use rubyish_method_name to define #each_all from #forall

### DIFF
--- a/gtk3/lib/gtk3/loader.rb
+++ b/gtk3/lib/gtk3/loader.rb
@@ -243,6 +243,8 @@ module Gtk
           # Ignore deprecated methods
           return
         end
+      when "Gtk::Container"
+        method_name = method_name.gsub("forall", "each_all")
       when "Gtk::IconSet"
         case method_name
         when "render_icon"

--- a/gtk3/lib/gtk3/loader.rb
+++ b/gtk3/lib/gtk3/loader.rb
@@ -244,7 +244,10 @@ module Gtk
           return
         end
       when "Gtk::Container"
-        method_name = method_name.gsub("forall", "each_all")
+        case method_name
+        when "forall"
+          method_name = "each_all"
+        end
       when "Gtk::IconSet"
         case method_name
         when "render_icon"


### PR DESCRIPTION
I use `rubyish_method_name` to define `#each_all` from `#forall`.
Actually, using `rubyish_method_name` is Ruby-GNOME2 way.
It was beyond my thought when implementing my first patch.