### PR TITLE
update to gtk3 api  and update copyright in togglebutton.rb

### DIFF
--- a/gtk3/sample/misc/togglebutton.rb
+++ b/gtk3/sample/misc/togglebutton.rb
@@ -2,13 +2,11 @@
 =begin
   togglebutton.rb - Ruby/GTK sample script.
 
-  Copyright (c) 2002-2006 Ruby-GNOME2 Project Team 
+  Copyright (c) 2002-2015 Ruby-GNOME2 Project Team
   This program is licenced under the same licence as Ruby-GNOME2.
-
-  $Id: togglebutton.rb,v 1.10 2006/06/17 13:18:12 mutoh Exp $
 =end
 
-require 'gtk3'
+require "gtk3"
 
 window = Gtk::Window.new("Gtk::ToggleButton sample")
 window.border_width = 10
@@ -16,10 +14,10 @@ window.border_width = 10
 box = Gtk::Box.new(:vertical, 10)
 window.add(box)
 
-button1 = Gtk::ToggleButton.new("_button1")
-button2 = Gtk::ToggleButton.new("_button2",false)
-button3 = Gtk::ToggleButton.new(Gtk::Stock::QUIT)
-box.add(button1).add(button2).add(button3)
+button1 = Gtk::ToggleButton.new(:label => "_button1", :use_underline => true)
+button2 = Gtk::ToggleButton.new(:label => "_button2", :use_underline => false)
+box.add(button1)
+box.add(button2)
 
 box.pack_start(Gtk::Separator.new(:horizontal))
 


### PR DESCRIPTION
It was because of this sample that I was reluctant to use the symbol :use_underline and that I used :mnemonic. On my system when I launch it, the button with :use_underline => true is not underlined but the mnemonic works.

regards