### PR TITLE
add support for Gtk::TargetFlags symbols for Gtk::Widget#drag_dest_set

### DIFF
--- a/gtk3/lib/gtk3/loader.rb
+++ b/gtk3/lib/gtk3/loader.rb
@@ -123,6 +123,7 @@ module Gtk
       require "gtk3/style-context"
       require "gtk3/style-properties"
       require "gtk3/target-list"
+      require "gtk3/target-entry"
       require "gtk3/text-buffer"
       require "gtk3/text-tag-table"
       require "gtk3/toggle-action"

--- a/gtk3/lib/gtk3/target-entry.rb
+++ b/gtk3/lib/gtk3/target-entry.rb
@@ -1,0 +1,27 @@
+# Copyright (C) 2015  Ruby-GNOME2 Project Team
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+
+module Gtk
+  class TargetEntry
+    alias_method :initialize_raw, :initialize
+    def initialize(target, flags, info)
+      unless flags.is_a?(Gtk::TargetFlags)
+        flags = Gtk::TargetFlags.new(flags).to_i
+      end
+      initialize_raw(target, flags, info) 
+    end
+  end
+end

--- a/gtk3/lib/gtk3/widget.rb
+++ b/gtk3/lib/gtk3/widget.rb
@@ -59,6 +59,9 @@ module Gtk
       targets.collect do |target|
         case target
         when Array
+          unless target[1].is_a?(Gtk::TargetFlags)
+            target[1] = Gtk::TargetFlags.new(target[1]).to_i
+          end
           TargetEntry.new(*target)
         else
           target

--- a/gtk3/lib/gtk3/widget.rb
+++ b/gtk3/lib/gtk3/widget.rb
@@ -59,10 +59,7 @@ module Gtk
       targets.collect do |target|
         case target
         when Array
-          unless target[1].is_a?(Gtk::TargetFlags)
-            target[1] = Gtk::TargetFlags.new(target[1]).to_i
-          end
-          TargetEntry.new(*target)
+            TargetEntry.new(*target)
         else
           target
         end


### PR DESCRIPTION
I don't know if it is the rigth way to do this. I just imited you from a recent commit.

This solve a pb I had witht the script sample/misc/dnd.rb

```ruby
    drag_dest_set(Gtk::DestDefaults::MOTION |
                  Gtk::DestDefaults::HIGHLIGHT,
#                  [["test", :same_app, 12345]],
                  [["test", Gtk::TargetFlags::SAME_APP, 12345]],
                  Gdk::DragAction::COPY |
                  Gdk::DragAction::MOVE)
```
The line in comments above does work with my patch