### PR TITLE
    glib2: Use NUM2ULONG instead of NUM2UINT in GLib.format_size

### DIFF
--- a/glib2/ext/glib2/rbglib_fileutils.c
+++ b/glib2/ext/glib2/rbglib_fileutils.c
@@ -53,7 +53,7 @@ void        g_dir_close                     (GDir *dir);
 static VALUE
 rbglib_m_format_size_for_display(G_GNUC_UNUSED VALUE self, VALUE size)
 {
-    return CSTR2RVAL_FREE(g_format_size_for_display(NUM2INT(size)));
+    return CSTR2RVAL_FREE(g_format_size_for_display(NUM2ULONG(size)));
 }
 #endif
 
@@ -65,14 +65,14 @@ rbglib_m_format_size(int argc, VALUE *argv, G_GNUC_UNUSED VALUE self)
 
     rb_scan_args(argc, argv, "11", &rb_size, &rb_options);
     if (NIL_P(rb_options)) {
-      return CSTR2RVAL_FREE(g_format_size(NUM2UINT(rb_size)));
+      return CSTR2RVAL_FREE(g_format_size(NUM2ULONG(rb_size)));
     } else {
       VALUE rb_flags;
       rbg_scan_options(rb_options,
                        "flags", &rb_flags,
                        NULL);
 
-      return CSTR2RVAL_FREE(g_format_size_full(NUM2UINT(rb_size),
+      return CSTR2RVAL_FREE(g_format_size_full(NUM2ULONG(rb_size),
                                                RVAL2GFORMATSIZEFLAGS(rb_flags)));
     }
 }

--- a/glib2/test/test_file_utils.rb
+++ b/glib2/test/test_file_utils.rb
@@ -5,31 +5,31 @@ class TestGLibFileUtils < Test::Unit::TestCase
 
   sub_test_case "#format_size_for_display" do
     def setup
-    only_glib_version(2, 16, 0)
+      only_glib_version(2, 16, 0)
     end
 
     def test_kb
-    assert_equal("1.0 KB", GLib.format_size_for_display(1024))
+      assert_equal("1.0 KB", GLib.format_size_for_display(1024))
     end
 
     def test_10kb
-    assert_equal("10.0 KB", GLib.format_size_for_display(1024 * 10))
+      assert_equal("10.0 KB", GLib.format_size_for_display(1024 * 10))
     end
 
     def test_1mb
-    assert_equal("1.0 MB", GLib.format_size_for_display(1024 * 1024))
+      assert_equal("1.0 MB", GLib.format_size_for_display(1024 * 1024))
     end
 
     def test_1_5mb
-    assert_equal("1.5 MB", GLib.format_size_for_display(1024 * 1024 * 1.5))
+      assert_equal("1.5 MB", GLib.format_size_for_display(1024 * 1024 * 1.5))
     end
 
     def test_1gb
-    assert_equal("1.0 GB", GLib.format_size_for_display(1024 * 1024 * 1024))
+      assert_equal("1.0 GB", GLib.format_size_for_display(1024 * 1024 * 1024))
     end
 
     def test_over_guint32_value
-    assert_equal("4.0 GB", GLib.format_size_for_display((2**32-1) + 1))
+      assert_equal("4.0 GB", GLib.format_size_for_display((2**32-1) + 1))
     end
   end
 

--- a/glib2/test/test_file_utils.rb
+++ b/glib2/test/test_file_utils.rb
@@ -21,7 +21,8 @@ class TestGLibFileUtils < Test::Unit::TestCase
     end
 
     def test_over_guint32_value
-      assert_equal("4.0 GB", GLib.format_size_for_display((2**32-1) + 1))
+      guint32_max = 2 ** 32 - 1
+      assert_equal("4.0 GB", GLib.format_size_for_display(guint32_max + 1))
     end
   end
 
@@ -43,7 +44,8 @@ class TestGLibFileUtils < Test::Unit::TestCase
     end
 
     def test_over_guint32_value
-      assert_equal("4.3 GB", GLib.format_size((2**32-1) + 1))
+      guint32_max = 2 ** 32 - 1
+      assert_equal("4.3 GB", GLib.format_size(guint32_max + 1))
     end
 
     sub_test_case "flags" do

--- a/glib2/test/test_file_utils.rb
+++ b/glib2/test/test_file_utils.rb
@@ -4,14 +4,33 @@ class TestGLibFileUtils < Test::Unit::TestCase
   include GLibTestUtils
 
   sub_test_case "#format_size_for_display" do
+    def setup
     only_glib_version(2, 16, 0)
+    end
 
+    def test_kb
     assert_equal("1.0 KB", GLib.format_size_for_display(1024))
+    end
+
+    def test_10kb
     assert_equal("10.0 KB", GLib.format_size_for_display(1024 * 10))
+    end
+
+    def test_1mb
     assert_equal("1.0 MB", GLib.format_size_for_display(1024 * 1024))
+    end
+
+    def test_1_5mb
     assert_equal("1.5 MB", GLib.format_size_for_display(1024 * 1024 * 1.5))
+    end
+
+    def test_1gb
     assert_equal("1.0 GB", GLib.format_size_for_display(1024 * 1024 * 1024))
+    end
+
+    def test_over_guint32_value
     assert_equal("4.0 GB", GLib.format_size_for_display((2**32-1) + 1))
+    end
   end
 
   sub_test_case "#format_size" do

--- a/glib2/test/test_file_utils.rb
+++ b/glib2/test/test_file_utils.rb
@@ -12,16 +12,8 @@ class TestGLibFileUtils < Test::Unit::TestCase
       assert_equal("1.0 KB", GLib.format_size_for_display(1024))
     end
 
-    def test_10kb
-      assert_equal("10.0 KB", GLib.format_size_for_display(1024 * 10))
-    end
-
     def test_1mb
       assert_equal("1.0 MB", GLib.format_size_for_display(1024 * 1024))
-    end
-
-    def test_1_5mb
-      assert_equal("1.5 MB", GLib.format_size_for_display(1024 * 1024 * 1.5))
     end
 
     def test_1gb

--- a/glib2/test/test_file_utils.rb
+++ b/glib2/test/test_file_utils.rb
@@ -3,7 +3,7 @@
 class TestGLibFileUtils < Test::Unit::TestCase
   include GLibTestUtils
 
-  def test_format_size_for_display
+  sub_test_case "#format_size_for_display" do
     only_glib_version(2, 16, 0)
 
     assert_equal("1.0 KB", GLib.format_size_for_display(1024))

--- a/glib2/test/test_file_utils.rb
+++ b/glib2/test/test_file_utils.rb
@@ -12,11 +12,11 @@ class TestGLibFileUtils < Test::Unit::TestCase
       assert_equal("1.0 KB", GLib.format_size_for_display(1024))
     end
 
-    def test_1mb
+    def test_mb
       assert_equal("1.0 MB", GLib.format_size_for_display(1024 * 1024))
     end
 
-    def test_1gb
+    def test_gb
       assert_equal("1.0 GB", GLib.format_size_for_display(1024 * 1024 * 1024))
     end
 

--- a/glib2/test/test_file_utils.rb
+++ b/glib2/test/test_file_utils.rb
@@ -30,6 +30,10 @@ class TestGLibFileUtils < Test::Unit::TestCase
       assert_equal("1.0 GB", GLib.format_size(1000 * 1000 * 1000))
     end
 
+    def test_5gb
+      assert_equal("5.0 GB", GLib.format_size(1000 * 1000 * 1000 * 5))
+    end
+
     sub_test_case "flags" do
       sub_test_case ":iec_units" do
         def format_size(size)

--- a/glib2/test/test_file_utils.rb
+++ b/glib2/test/test_file_utils.rb
@@ -31,7 +31,7 @@ class TestGLibFileUtils < Test::Unit::TestCase
     end
 
     def test_over_guint32_value
-      assert_equal("5.0 GB", GLib.format_size(1000 * 1000 * 1000 * 5))
+      assert_equal("4.3 GB", GLib.format_size((2**32-1) + 1))
     end
 
     sub_test_case "flags" do

--- a/glib2/test/test_file_utils.rb
+++ b/glib2/test/test_file_utils.rb
@@ -11,6 +11,7 @@ class TestGLibFileUtils < Test::Unit::TestCase
     assert_equal("1.0 MB", GLib.format_size_for_display(1024 * 1024))
     assert_equal("1.5 MB", GLib.format_size_for_display(1024 * 1024 * 1.5))
     assert_equal("1.0 GB", GLib.format_size_for_display(1024 * 1024 * 1024))
+    assert_equal("4.0 GB", GLib.format_size_for_display((2**32-1) + 1))
   end
 
   sub_test_case "#format_size" do

--- a/glib2/test/test_file_utils.rb
+++ b/glib2/test/test_file_utils.rb
@@ -30,7 +30,7 @@ class TestGLibFileUtils < Test::Unit::TestCase
       assert_equal("1.0 GB", GLib.format_size(1000 * 1000 * 1000))
     end
 
-    def test_5gb
+    def test_over_guint32_value
       assert_equal("5.0 GB", GLib.format_size(1000 * 1000 * 1000 * 5))
     end
 

--- a/glib2/test/test_file_utils.rb
+++ b/glib2/test/test_file_utils.rb
@@ -12,6 +12,10 @@ class TestGLibFileUtils < Test::Unit::TestCase
       assert_equal("1.0 KB", GLib.format_size_for_display(1024))
     end
 
+    def test_10kb
+      assert_equal("10.0 KB", GLib.format_size_for_display(1024 * 10))
+    end
+
     def test_mb
       assert_equal("1.0 MB", GLib.format_size_for_display(1024 * 1024))
     end


### PR DESCRIPTION
fixes #413

Because following RangeError exception is thrown when GLib.format_size(1000 * 1000 * 1000 * 5):

    ```log
    Error: test_5gb(TestGLibFileUtils::#format_size)
    : RangeError: integer 5000000000 too big to convert to `unsigned int'
    ruby-gnome2/glib2/test/test_file_utils.rb:34:in
    `format_size'
    ruby-gnome2/glib2/test/test_file_utils.rb:34:in
    `test_5gb'
         31:     end
         32:
         33:     def test_5gb
      => 34:       assert_equal("5.0 GB", GLib.format_size(1000 * 1000 * 1000 * 5))
         35:     end
         36:
         37:     sub_test_case "flags" do
    ```