### PR TITLE
gtk3: add support for widget template

### DIFF
--- a/gtk3/ext/gtk3/rb-gtk3-container.c
+++ b/gtk3/ext/gtk3/rb-gtk3-container.c
@@ -98,11 +98,15 @@ static void
 class_init_func(gpointer g_class, gpointer class_data)
 {
     GtkContainerClass *g_container_class = GTK_CONTAINER_CLASS(g_class);
+    VALUE rb_class;
 
     rbgobj_class_init_func(g_class, class_data);
 
     g_container_class->set_child_property = set_child_prop_func;
     g_container_class->get_child_property = get_child_prop_func;
+
+    rb_class = GTYPE2CLASS(G_TYPE_FROM_CLASS(g_class));
+    rb_funcall(rb_class, rb_intern("init"), 0);
 }
 
 static VALUE
@@ -114,6 +118,8 @@ rg_initialize(int argc, VALUE *argv, VALUE self)
 
     object = RVAL2GOBJ(self);
     g_object_ref_sink(object);
+
+    rb_funcall(self, rb_intern("initialize_post"), 0);
 
     return Qnil;
 }

--- a/gtk3/sample/misc/template.gresource.xml
+++ b/gtk3/sample/misc/template.gresource.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<gresources>
+  <gresource prefix="/template">
+    <file>template.ui</file>
+  </gresource>
+</gresources>

--- a/gtk3/sample/misc/template.ui
+++ b/gtk3/sample/misc/template.ui
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Generated with glade 3.18.3 -->
+<interface>
+  <requires lib="gtk+" version="3.12"/>
+  <template class="MyWindow" parent="GtkWindow">
+    <property name="can_focus">False</property>
+    <child>
+      <object class="GtkLabel" id="label">
+        <property name="visible">True</property>
+        <property name="can_focus">False</property>
+        <property name="label" translatable="yes">label</property>
+        <property name="ellipsize">end</property>
+      </object>
+    </child>
+  </template>
+</interface>

--- a/gtk3/sample/misc/template_from_resource.rb
+++ b/gtk3/sample/misc/template_from_resource.rb
@@ -1,0 +1,59 @@
+#!/usr/bin/env ruby
+=begin
+  template_from_resource.rb - Ruby/GTK sample script.
+
+  Copyright (c) 2015 Ruby-GNOME2 Project Team
+  This program is licenced under the same licence as Ruby-GNOME2.
+=end
+
+require "gtk3"
+require "fileutils"
+
+current_path = File.expand_path(File.dirname(__FILE__))
+
+# The gresource file name
+gresource_bin = "#{current_path}/template.gresource"
+
+# The gresource xml file name
+# see here https://developer.gnome.org/gio/stable/GResource.html
+gresource_xml = "#{current_path}/template.gresource.xml"
+
+# Generate the resource file:
+# see here https://developer.gnome.org/gio/stable/glib-compile-resources.html
+Dir.chdir(File.dirname(gresource_xml)) do
+  system("glib-compile-resources",
+         "--target", gresource_bin,
+         File.basename(gresource_xml))
+end
+
+at_exit do
+  FileUtils.rm_f(gresource_bin)
+end
+
+resource = Gio::Resource.load(gresource_bin)
+Gio::Resources.register(resource)
+
+class MyWindow < Gtk::Window
+  class << self
+    def init
+      set_template(:resource => "/template/template.ui")
+      bind_template_child("label")
+    end
+  end
+
+  type_register
+end
+
+window = MyWindow.new
+window.set_title "Build interface from resource"
+window.set_default_size 300, 300
+
+window.label.text = "My UI was created with Glade"
+
+window.show_all
+
+window.signal_connect "destroy" do
+  Gtk.main_quit
+  Gio::Resources.unregister(resource)
+end
+Gtk.main

--- a/gtk3/test/fixture/Rakefile
+++ b/gtk3/test/fixture/Rakefile
@@ -18,14 +18,15 @@
 
 require "rake/clean"
 
-gresource = "simple_window.gresource"
-gresource_xml = "#{gresource}.xml"
+gresources = ["simple_window.gresource", "template.gresource"]
 
-dependencies = [gresource_xml]
-
-CLEAN << gresource
-file gresource => dependencies do
-  sh("glib-compile-resources", gresource_xml)
+gresources.each do |gresource|
+  gresource_xml = "#{gresource}.xml"
+  dependencies = [gresource_xml]
+  CLEAN << gresource
+  file gresource => dependencies do
+    sh("glib-compile-resources", gresource_xml)
+  end
 end
 
-task :default => gresource
+task :default => gresources

--- a/gtk3/test/fixture/template.gresource.xml
+++ b/gtk3/test/fixture/template.gresource.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<gresources>
+  <gresource prefix="/template">
+    <file>template.ui</file>
+  </gresource>
+</gresources>

--- a/gtk3/test/fixture/template.ui
+++ b/gtk3/test/fixture/template.ui
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Generated with glade 3.18.3 -->
+<interface>
+  <requires lib="gtk+" version="3.12"/>
+  <template class="TestGtkContainerTestTemplateMyWindow" parent="GtkWindow">
+    <property name="can_focus">False</property>
+    <child>
+      <object class="GtkLabel" id="label">
+        <property name="visible">True</property>
+        <property name="can_focus">False</property>
+        <property name="label" translatable="yes">label</property>
+        <property name="ellipsize">end</property>
+      </object>
+    </child>
+  </template>
+</interface>


### PR DESCRIPTION
This patch tries to add support for GTK widget template.  With this, users don't need to manually call ```builder.get_object()```.

The implementation is similar to the one in Gjs:
https://bugzilla.gnome.org/show_bug.cgi?id=700347

At the moment, I don't request merging this to the upstream, but would like to hear opinions on the desired Ruby interface of the widget template support, e.g., automatic mapping between widgets and accessors.

Comments would be appreciated.