### PR TITLE
Setup the model of the returned Gtk::TreeIter

### DIFF
--- a/gtk3/lib/gtk3/list-store.rb
+++ b/gtk3/lib/gtk3/list-store.rb
@@ -49,5 +49,12 @@ module Gtk
       setup_iter(iter)
       iter
     end
+  
+    alias_method :prepend_raw, :prepend
+    def prepend
+      iter = prepend_raw
+      setup_iter(iter)
+      iter
+    end
   end
 end

--- a/gtk3/lib/gtk3/list-store.rb
+++ b/gtk3/lib/gtk3/list-store.rb
@@ -56,5 +56,12 @@ module Gtk
       setup_iter(iter)
       iter
     end
+    
+    alias_method :insert_raw, :insert
+    def insert(index)
+      iter = insert_raw(index)
+      setup_iter(iter)
+      iter
+    end
   end
 end


### PR DESCRIPTION
Setup the model of the resulting `Gtk::TreeIter`  returned by `Gtk::ListStore#prepend`

Fix this kind of pb:

```ruby
model = Gtk::ListStore.new(TrueClass, String)
model.prepend.set_values([true, "item5"])
```

that returns:

```
/home/cedlemo/.gem/ruby/2.2.0/gems/gtk3-2.2.6/lib/gtk3/tree-iter.rb:38:in `set_values': undefined method `set_values' for nil:NilClass (NoMethodError)
```