### PR TITLE
Setup model in returned iter from Gtk::TreeModelFilter#convert_iter_t…

### DIFF
--- a/gtk3/lib/gtk3/loader.rb
+++ b/gtk3/lib/gtk3/loader.rb
@@ -139,6 +139,7 @@ module Gtk
       require "gtk3/tool-button"
       require "gtk3/tree-iter"
       require "gtk3/tree-model"
+      require "gtk3/tree-model-filter"
       require "gtk3/tree-path"
       require "gtk3/tree-selection"
       require "gtk3/tree-store"

--- a/gtk3/lib/gtk3/tree-model-filter.rb
+++ b/gtk3/lib/gtk3/tree-model-filter.rb
@@ -1,0 +1,27 @@
+# Copyright (C) 2015  Ruby-GNOME2 Project Team
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+
+module Gtk
+  class TreeModelFilter
+  
+    alias_method :convert_iter_to_child_iter_raw, :convert_iter_to_child_iter
+    def convert_iter_to_child_iter(iter)
+      child_iter = convert_iter_to_child_iter_raw(iter)
+      child_iter.model = child_model
+      child_iter
+    end
+  end
+end


### PR DESCRIPTION
Setup model in returned iter from Gtk::TreeModelFilter#convert_iter_to_child_iter,

I guess I have the same thing to do for `gtk_tree_model_filter_convert_child_iter_to_iter`