### PR TITLE
Remove dependancy to test-unit-notify gem

### DIFF
--- a/atk/test/atk-test-utils.rb
+++ b/atk/test/atk-test-utils.rb
@@ -15,7 +15,6 @@
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 
 require "test-unit"
-require "test/unit/notify"
 
 module AtkTestUtils
 end

--- a/cairo-gobject/test/cairo-gobject-test-utils.rb
+++ b/cairo-gobject/test/cairo-gobject-test-utils.rb
@@ -15,7 +15,6 @@
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 
 require "test-unit"
-require "test/unit/notify"
 
 module CairoGObjectTestUtils
 end

--- a/clutter-gstreamer/test/clutter-gstreamer-test-utils.rb
+++ b/clutter-gstreamer/test/clutter-gstreamer-test-utils.rb
@@ -15,7 +15,6 @@
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 
 require "test-unit"
-require "test/unit/notify"
 
 module ClutterGStreamerTestUtils
   def later_version?(major, minor, micro=nil)

--- a/clutter-gtk/test/clutter-gtk-test-utils.rb
+++ b/clutter-gtk/test/clutter-gtk-test-utils.rb
@@ -15,7 +15,6 @@
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 
 require "test-unit"
-require "test/unit/notify"
 
 module ClutterGtkTestUtils
 end

--- a/clutter/test/clutter-test-utils.rb
+++ b/clutter/test/clutter-test-utils.rb
@@ -15,7 +15,6 @@
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 
 require "test-unit"
-require "test/unit/notify"
 
 module ClutterTestUtils
   private

--- a/gdk3-no-gi/test/gdk-test-utils.rb
+++ b/gdk3-no-gi/test/gdk-test-utils.rb
@@ -15,7 +15,6 @@
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 
 require "test-unit"
-require "test/unit/notify"
 
 module GdkTestUtils
 end

--- a/gdk3/test/gdk-test-utils.rb
+++ b/gdk3/test/gdk-test-utils.rb
@@ -15,7 +15,6 @@
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 
 require "test-unit"
-require "test/unit/notify"
 
 module GdkTestUtils
   private

--- a/gio2/test/gio2-test-utils.rb
+++ b/gio2/test/gio2-test-utils.rb
@@ -15,7 +15,6 @@
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 
 require "test-unit"
-require "test/unit/notify"
 
 require "gio2-test-utils/fixture"
 require "gio2-test-utils/omissions"

--- a/gobject-introspection/test/gobject-introspection-test-utils.rb
+++ b/gobject-introspection/test/gobject-introspection-test-utils.rb
@@ -15,7 +15,6 @@
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 
 require "test-unit"
-require "test/unit/notify"
 
 module GObjectIntrospectionTestUtils
   def require_version(major, minor, micro)

--- a/rsvg2/test/rsvg2-test-utils.rb
+++ b/rsvg2/test/rsvg2-test-utils.rb
@@ -15,7 +15,6 @@
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 
 require "test-unit"
-require "test/unit/notify"
 
 require "fileutils"
 

--- a/vte3/test/vte3-test-utils.rb
+++ b/vte3/test/vte3-test-utils.rb
@@ -15,7 +15,6 @@
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 
 require "test-unit"
-require "test/unit/notify"
 
 module VteTestUtils
   private

--- a/webkit-gtk/test/webkit-gtk-test-utils.rb
+++ b/webkit-gtk/test/webkit-gtk-test-utils.rb
@@ -15,7 +15,6 @@
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 
 require "test-unit"
-require "test/unit/notify"
 
 require "webkit-gtk-test-utils/omissions"
 

--- a/webkit-gtk2/test/webkit-gtk-test-utils.rb
+++ b/webkit-gtk2/test/webkit-gtk-test-utils.rb
@@ -15,7 +15,6 @@
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 
 require "test-unit"
-require "test/unit/notify"
 
 require "webkit-gtk-test-utils/omissions"
 


### PR DESCRIPTION
All references have been found with:

    find ./ -type f -name "*.rb"| xargs grep -l "unit/notify"