### PR TITLE
Add support for native gobject-introspection package installation for…

### DIFF
--- a/glib2/lib/mkmf-gnome2.rb
+++ b/glib2/lib/mkmf-gnome2.rb
@@ -503,6 +503,8 @@ def package_platform
     :redhat
   elsif File.exist?("/etc/SuSE-release")
     :suse
+  elsif find_executable("pacman")
+    :arch
   elsif find_executable("brew")
     :homebrew
   elsif find_executable("port")
@@ -545,6 +547,8 @@ def install_missing_native_package(native_package_info)
     install_command = "brew install #{package_command_line}"
   when :macports
     install_command = "port install -y #{package_command_line}"
+  when :arch
+    install_command = "pacman -S --noconfirm #{package_command_line}"
   else
     return false
   end

--- a/gobject-introspection/ext/gobject-introspection/extconf.rb
+++ b/gobject-introspection/ext/gobject-introspection/extconf.rb
@@ -60,6 +60,7 @@ unless required_pkg_config_package(package_id,
                                    :debian => "libgirepository1.0-dev",
                                    :redhat => "gobject-introspection-devel",
                                    :homebrew => "gobject-introspection",
+                                   :arch => "gobject-introspection",
                                    :macports => "gobject-introspection")
   exit(false)
 end


### PR DESCRIPTION
… Arch Linux.

I did confirm that the native system package was installed automatically. I hope it helps.