### PR TITLE
Remove reference to test-unit-notify in some Rakefile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -19,7 +19,6 @@ source "https://rubygems.org/"
 gem "rake"
 gem "pkg-config"
 gem "cairo"
-gem "test-unit-notify"
 
 local_gemfile = File.join(File.dirname(__FILE__), "Gemfile.local")
 if File.exists?(local_gemfile)

--- a/cairo-gobject/Rakefile
+++ b/cairo-gobject/Rakefile
@@ -23,7 +23,6 @@ package_task = GNOME2::Rake::PackageTask.new do |package|
   package.summary = "Ruby/CairoGObject is a Ruby binding of cairo-gobject."
   package.description = "Ruby/CairoGObject is a Ruby binding of cairo-gobject."
   package.dependency.gem.runtime = ["cairo", "glib2"]
-  package.dependency.gem.development = ["test-unit-notify"]
   package.windows.packages = []
   package.windows.dependencies = []
   package.windows.build_dependencies = ["cairo", "glib2"]

--- a/clutter-gstreamer/Rakefile
+++ b/clutter-gstreamer/Rakefile
@@ -23,7 +23,6 @@ package_task = GNOME2::Rake::PackageTask.new do |package|
   package.summary = "Ruby/ClutterGStreamer is a Ruby binding of Clutter-GStreamer."
   package.description = "Ruby/ClutterGStreamer is a Ruby binding of Clutter-GStreamer."
   package.dependency.gem.runtime = ["gdk_pixbuf2", "clutter", "gstreamer"]
-  package.dependency.gem.development = ["test-unit-notify"]
   package.windows.packages = []
   package.windows.dependencies = []
   package.windows.build_dependencies = [

--- a/clutter-gtk/Rakefile
+++ b/clutter-gtk/Rakefile
@@ -23,7 +23,6 @@ package_task = GNOME2::Rake::PackageTask.new do |package|
   package.summary = "Ruby/ClutterGTK is a Ruby binding of Clutter-GTK."
   package.description = "Ruby/ClutterGTK is a Ruby binding of Clutter-GTK."
   package.dependency.gem.runtime = ["clutter", "gtk3"]
-  package.dependency.gem.development = ["test-unit-notify"]
   package.windows.packages = []
   package.windows.dependencies = []
   package.windows.build_dependencies = [

--- a/clutter/Rakefile
+++ b/clutter/Rakefile
@@ -27,7 +27,6 @@ package_task = GNOME2::Rake::PackageTask.new do |package|
     "gobject-introspection",
     "pango"
   ]
-  package.dependency.gem.development = ["test-unit-notify"]
   package.windows.packages = []
   package.windows.dependencies = []
   package.windows.build_dependencies = [

--- a/webkit-gtk/Rakefile
+++ b/webkit-gtk/Rakefile
@@ -23,7 +23,6 @@ package_task = GNOME2::Rake::PackageTask.new do |package|
   package.summary = "Ruby/WebKitGTK is a Ruby binding of WebKitGTK+."
   package.description = "Ruby/WebKitGTK is a Ruby binding of WebKitGTK+."
   package.dependency.gem.runtime = ["gobject-introspection", "gtk3"]
-  package.dependency.gem.development = ["test-unit-notify"]
   package.windows.packages = []
   package.windows.dependencies = []
   package.windows.build_dependencies = [

--- a/webkit-gtk2/Rakefile
+++ b/webkit-gtk2/Rakefile
@@ -23,7 +23,6 @@ package_task = GNOME2::Rake::PackageTask.new do |package|
   package.summary = "Ruby/WebKitGtk2 is a Ruby binding of WebKitGTK+ for Gtk 2.0 Toolkit"
   package.description = "Ruby/WebKitGtk2 is a Ruby binding of WebKitGTK+ for Gtk 2.0 Toolkit"
   package.dependency.gem.runtime = ["gobject-introspection", "gtk2"]
-  package.dependency.gem.development = ["test-unit-notify"]
   package.windows.packages = []
   package.windows.dependencies = []
   package.windows.build_dependencies = ["glib2", "gobject-introspection"]

--- a/webkit2-gtk/Rakefile
+++ b/webkit2-gtk/Rakefile
@@ -23,7 +23,6 @@ package_task = GNOME2::Rake::PackageTask.new do |package|
   package.summary = "Ruby/WebKit2GTK is a Ruby binding of WebKit2GTK+."
   package.description = "Ruby/WebKit2GTK is a Ruby binding of WebKit2GTK+."
   package.dependency.gem.runtime = ["gobject-introspection", "gtk3"]
-  package.dependency.gem.development = ["test-unit-notify"]
   package.windows.packages = []
   package.windows.dependencies = []
   package.windows.build_dependencies = [


### PR DESCRIPTION
Sorry but when I checked for the test-unit-notify I just only search them in `*.rb` files

here is the command that returns me the files that remains:

```
find ./ -type f | xargs grep -l "test-unit-notify"
```