### PR TITLE
Add Arch Linux support for auto install of native Gtk3 package.

### DIFF
--- a/gtk3/ext/gtk3/extconf.rb
+++ b/gtk3/ext/gtk3/extconf.rb
@@ -67,6 +67,7 @@ unless required_pkg_config_package(package_id,
                                    :debian => "libgtk-3-dev",
                                    :redhat => "gtk3-devel",
                                    :homebrew => "gtk+3",
+                                   :arch => "gtk3",
                                    :macports => "gtk3")
   exit(false)
 end


### PR DESCRIPTION
Testing this was way harder than changing the code. I had to set up an Arch VM with a bunch of gui packages removed, to get Gtk3 to be removed.

I think it will be rare that users don't already have Gtk3 installed, but at least I have seen this change work.