### PR TITLE
Update TODO

### DIFF
--- a/gtk3/sample/gtk-demo/TODO
+++ b/gtk3/sample/gtk-demo/TODO
@@ -1,4 +1,4 @@
-# C version (3.17.6) versus Ruby version
+# C version (3.18.0) versus Ruby version
 
 C version             Ruby version    Updated
 application.c           no              no


### PR DESCRIPTION
The new gtk3 version is out 3.18, good news there are no new demos since the last check. But the main part has been rewriten using `Gtk::Application`. Should we do the same? (I would like because I thnk we should stay up to date)