### PR TITLE
Gtk3 sample gtk demo main rb list demos method

### DIFF
--- a/gtk3/sample/gtk-demo/main.rb
+++ b/gtk3/sample/gtk-demo/main.rb
@@ -84,9 +84,8 @@ def generate_index
 
       unless children[parent]
         children[parent] = []
-        index += [[parent, nil, nil, []]]
+        index += [[parent, nil, []]]
       end
-
       children[parent] += [[child, script]]
     else
       index += [[title, script]]
@@ -102,8 +101,8 @@ def generate_index
 
   # Expand children
   index.collect! do |row|
-    row[3] = children[row[0]] if row[3]
-
+    row[2] = children[row[0]] if row[2]
+      
     row
   end
 

--- a/gtk3/sample/gtk-demo/main.rb
+++ b/gtk3/sample/gtk-demo/main.rb
@@ -124,6 +124,15 @@ def append_children(model, source, parent = nil)
   end
 end
 
+def list_demos(source, is_child=false)
+  source.each do |title, filename, children|
+    tab = is_child ? "\t" : ""
+    puts "#{tab}#{title} #{filename||""}"
+
+    list_demos(children, true) if children
+  end
+end
+
 class Demo < Gtk::Application
   def initialize
     super("org.gtk.Demo", [:non_unique, :handles_command_line])
@@ -191,7 +200,7 @@ class Demo < Gtk::Application
   def run_application
     if @options[:list]
       puts "list"
-      # list_demos
+      list_demos(generate_index)
       quit
     end
 


### PR DESCRIPTION
There is an important fix in this pull request, when I simplified the code, the children where not well registred.

The list_demos method works when you launch:

    ./main.rb --list