### PR TITLE
add a test module and implement the use of test_mod.rb

### DIFF
--- a/gtk3/sample/gtk-demo/main.rb
+++ b/gtk3/sample/gtk-demo/main.rb
@@ -278,7 +278,22 @@ class Demo < Gtk::Application
       menu.popup(nil, nil, Gtk.current_event_time)
     end
 
+    treeview.signal_connect "row-activated" do |tree_view,path,column|
+      iter = model.get_iter(path)
+      filename = iter[1]
+      module_name =  get_module_name_from_filename(filename)
+
+      unless Module.const_defined?(module_name) == true
+        require filename if filename =~ /test_mod\.rb/ # We just use this for test now
+      end
+
+      module_object = Module::const_get(module_name)
+      module_object.send(:run_demo)
+
+    end
+
     window.show_all
+
   end
 end
 

--- a/gtk3/sample/gtk-demo/test_mod.rb
+++ b/gtk3/sample/gtk-demo/test_mod.rb
@@ -1,0 +1,14 @@
+# Copyright (c) 2008-2015 Ruby-GNOME2 Project Team
+# This program is licenced under the same licence as Ruby-GNOME2.
+#
+=begin
+= test demo 
+
+Demonstrates the demo interface.
+=end
+module TestModDemo
+
+  def self.run_demo
+    puts "ok"
+  end
+end


### PR DESCRIPTION
The test_mod.rb is only for the test and implementation purpose. It will be removed later (It just help me to focus on the way to load the demo files and code.