### PR TITLE
Make Gtk::Widget#translate_coordinates more rubyish

### DIFF
--- a/gtk3/lib/gtk3/widget.rb
+++ b/gtk3/lib/gtk3/widget.rb
@@ -106,6 +106,12 @@ module Gtk
       render_icon_pixbuf_raw(stock_id, size)
     end
 
+    alias_method :translate_coordinates_raw, :translate_coordinates
+    def translate_coordinates(widget, x, y)
+      translated, x, y = translate_coordinates_raw(widget, x, y)
+      return [x, y] if translated
+    end
+    
     private
     def initialize_post
       klass = self.class

--- a/gtk3/test/test-gtk-widget.rb
+++ b/gtk3/test/test-gtk-widget.rb
@@ -137,6 +137,35 @@ class TestGtkWidget < Test::Unit::TestCase
     end
   end
 
+  sub_test_case "#translate_coordinates" do
+    test "no common toplevel" do
+      win1 = Gtk::Window.new(:toplevel)
+      label1 = Gtk::Label.new("one")
+      win1.add(label1)    
+      win1.show_all
+
+      win2 = Gtk::Window.new(:toplevel)
+      label2 = Gtk::Label.new("one")
+      win2.add(label2)
+      win2.show_all
+
+      assert_equal(nil, label1.translate_coordinates(label2, 0, 0))
+    end
+    test "not realized" do
+      win1 = Gtk::Window.new(:toplevel)
+      label1 = Gtk::Label.new("one")
+      win1.add(label1)    
+      assert_equal(nil, label1.translate_coordinates(win1, 0, 0))
+    end
+    test "translated" do
+      win1 = Gtk::Window.new(:toplevel)
+      label1 = Gtk::Label.new("one")
+      win1.add(label1)    
+      win1.show_all
+      assert_equal([0, 0], label1.translate_coordinates(win1, 0, 0))
+    end
+  end
+
   sub_test_case "predicates" do
     test "#in_destruction?" do
       entry = Gtk::Entry.new


### PR DESCRIPTION
`Gtk::Widget#translate_coordinates` returns an array like this [x, y] if it works or nil.