### PR TITLE
glib2: fix handling of 64 bits FIXNUM variant initialization

### DIFF
--- a/glib2/ext/glib2/rbglib-variant.c
+++ b/glib2/ext/glib2/rbglib-variant.c
@@ -95,7 +95,7 @@ rg_initialize(int argc, VALUE *argv, VALUE self)
             variant_type = G_VARIANT_TYPE_BOOLEAN;
             break;
           case RUBY_T_FIXNUM:
-            variant_type = G_VARIANT_TYPE_INT32;
+            variant_type = G_VARIANT_TYPE_INT64;
             break;
           case RUBY_T_FLOAT:
             variant_type = G_VARIANT_TYPE_DOUBLE;


### PR DESCRIPTION
This fixes the following error:

irb(main):001:0> require 'glib2'
=> true
irb(main):002:0> GLib::Variant.new(333222111000)
RangeError: integer 333222111000 too big to convert to `int'
            from (irb):2:in `initialize'
            from (irb):2:in `new'
            from (irb):2
            from /usr/bin/irb:11:in `<main>'