### PR TITLE
Glib2 regex match all

### DIFF
--- a/glib2/ext/glib2/rbglib_matchinfo.c
+++ b/glib2/ext/glib2/rbglib_matchinfo.c
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2015  Ruby-GNOME2 Project Team
+ *  Copyright (C) 2015-2016  Ruby-GNOME2 Project Team
  *
  *  This library is free software; you can redistribute it and/or
  *  modify it under the terms of the GNU Lesser General Public

--- a/glib2/ext/glib2/rbglib_matchinfo.c
+++ b/glib2/ext/glib2/rbglib_matchinfo.c
@@ -39,7 +39,13 @@ rg_string(VALUE self)
 static VALUE
 rg_matches_p(VALUE self)
 {
-  return CBOOL2RVAL(g_match_info_matches(_SELF(self)));
+    return CBOOL2RVAL(g_match_info_matches(_SELF(self)));
+}
+
+static VALUE
+rg_match_count(VALUE self)
+{
+    return INT2NUM(g_match_info_get_match_count(_SELF(self)));
 }
 
 void
@@ -51,4 +57,5 @@ Init_glib_matchinfo(void)
     RG_DEF_METHOD(regex, 0);
     RG_DEF_METHOD(string, 0);
     RG_DEF_METHOD_P(matches, 0);
+    RG_DEF_METHOD(match_count, 0);
 }

--- a/glib2/test/test-regex.rb
+++ b/glib2/test/test-regex.rb
@@ -208,23 +208,23 @@ class TestRegex < Test::Unit::TestCase
       end
     end
   end
-  
+
   sub_test_case "match_all" do
-    
+
     test "no match" do
       regex = GLib::Regex.new("[A-Z]+")
-      assert do 
+      assert do
         not regex.match_all("abc def").matches?
       end
     end
-    
+
     test "match" do
       regex = GLib::Regex.new("[A-Z]+")
       assert do
         regex.match_all("abc DEF", 0).matches?
       end
     end
-    
+
     test "match all" do
       regex = GLib::Regex.new("<.*>")
       assert_equal(3, regex.match_all("<a> <b> <c>").match_count)

--- a/glib2/test/test-regex.rb
+++ b/glib2/test/test-regex.rb
@@ -204,8 +204,30 @@ class TestRegex < Test::Unit::TestCase
 
     test "false" do
       assert do
-       not GLib::Regex.match?("ti", "tatota")
+        not GLib::Regex.match?("ti", "tatota")
       end
+    end
+  end
+  
+  sub_test_case "match_all" do
+    
+    test "no match" do
+      regex = GLib::Regex.new("[A-Z]+")
+      assert do 
+        not regex.match_all("abc def").matches?
+      end
+    end
+    
+    test "match" do
+      regex = GLib::Regex.new("[A-Z]+")
+      assert do
+        regex.match_all("abc DEF", 0).matches?
+      end
+    end
+    
+    test "match all" do
+      regex = GLib::Regex.new("<.*>")
+      assert_equal(3, regex.match_all("<a> <b> <c>").match_count)
     end
   end
 end


### PR DESCRIPTION
For the next pull requests: 

*    Should I have to implement `GLib::Regex.split` ( ``g_regex_split_simple`) in ruby using the method `GLib::Regex#split` like we did previously for `g_regex_match_simple`.
