### PR TITLE
travis: Try to use trusty beta image

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,5 @@
+sudo: required
+dist: trusty
 env:
   global:
     - DISPLAY=":99.0"

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,6 @@ notifications:
     recipients:
       - ruby-gnome2-cvs@lists.sourceforge.net
 rvm:
-  - 2.0.0
   - 2.1
   - 2.2
   - 2.3.0

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,8 @@ matrix:
   # allow_failures:
   #   - rvm: 2.1
   fast_finish: true
+before_install:
+  - gem instal bundler
 before_script:
   - ./travis-before-script.sh
   - sh -e /etc/init.d/xvfb start

--- a/travis-before-script.sh
+++ b/travis-before-script.sh
@@ -28,6 +28,7 @@ sudo apt-get install -qq -y \
     gstreamer1.0-plugins-good \
     gir1.2-clutter-1.0 \
     gir1.2-clutter-gst-2.0 \
+    gir1.2-gtkclutter-1.0 \
     gir1.2-gtksource-3.0 \
     gir1.2-vte-2.90 \
     gir1.2-webkit-1.0 \

--- a/travis-before-script.sh
+++ b/travis-before-script.sh
@@ -23,14 +23,15 @@ if ! apt-cache show gir1.2-gstreamer-1.0 > /dev/null 2>&1; then
     sudo add-apt-repository --yes ppa:gstreamer-developers/ppa
 fi
 sudo apt-get update -qq
-# TODO: we'll use gir1.2-webkit2-3.0
-#       if it's supported in Travis CI.
 sudo apt-get install -qq -y \
     libgirepository1.0-dev \
     gstreamer1.0-plugins-good \
+    gir1.2-clutter-1.0 \
+    gir1.2-clutter-gst-2.0 \
     gir1.2-gtksource-3.0 \
     gir1.2-vte-2.90 \
     gir1.2-webkit-1.0 \
     gir1.2-webkit-3.0 \
+    gir1.2-webkit2-3.0 \
     gnome-icon-theme \
     dbus-x11


### PR DESCRIPTION
Related to https://github.com/ruby-gnome2/ruby-gnome2/issues/706.

* Start to use `dist: trusty`
* Install additional gi packages
  * clutter
  * clutter-gst
  * gtkclutter
  * webkit2
* Drop Ruby 2.0.0 support
* Use latest bundler