### PR TITLE
Glib2 regex check replacement

### DIFF
--- a/glib2/ext/glib2/rbglib_regex.c
+++ b/glib2/ext/glib2/rbglib_regex.c
@@ -325,6 +325,29 @@ rg_s_escape_string(G_GNUC_UNUSED VALUE self, VALUE string)
     return CSTR2RVAL(g_regex_escape_string(RVAL2CSTR(string), RSTRING_LEN(string)));
 }
 
+  static VALUE
+rg_s_check_replacement(G_GNUC_UNUSED VALUE self, VALUE rb_replacement)
+{
+    gboolean is_valid, has_ref;
+    const gchar * replacement = RVAL2CSTR(rb_replacement);
+    GError *error = NULL;
+    VALUE boolean_val;
+
+    is_valid = g_regex_check_replacement(replacement, &has_ref, &error);
+
+    if (error)
+        RAISE_GERROR(error);
+
+    VALUE ret = rb_ary_new();
+
+    boolean_val = is_valid == TRUE ? Qtrue : Qfalse;
+    rb_ary_push(ret, boolean_val);
+    boolean_val = has_ref == TRUE ? Qtrue : Qfalse;
+    rb_ary_push(ret, boolean_val);
+
+    return ret;
+}
+
 void
 Init_glib_regex(void)
 {
@@ -345,6 +368,7 @@ Init_glib_regex(void)
     RG_DEF_METHOD(replace, -1);
 
     RG_DEF_SMETHOD(escape_string, 1);
+    RG_DEF_SMETHOD(check_replacement, 1);
 
     G_DEF_CLASS(G_TYPE_REGEX_MATCH_FLAGS, "RegexMatchFlags", mGLib);
     G_DEF_CLASS(G_TYPE_REGEX_COMPILE_FLAGS, "RegexCompileFlags", mGLib);

--- a/glib2/test/test-regex.rb
+++ b/glib2/test/test-regex.rb
@@ -269,4 +269,16 @@ class TestRegex < Test::Unit::TestCase
                                  :literal => true))
     end
   end
+
+  sub_test_case "check_replacement" do
+    test "no references" do
+      assert_equal([true, false],
+                   GLib::Regex.check_replacement("foo\n"))
+    end
+
+    test "with references" do
+      assert_equal([true, true],
+                   GLib::Regex.check_replacement("\\0\\1"))
+    end
+  end
 end


### PR DESCRIPTION
Maybe you won't agree with this. I wait for your advices.

It remains to do the `GLib::Regex#replace_eval` which will be tricky. Do you want that I do the simple methods for `GLib::MacthInfo` before it?

If you want that I do the `GLib::Regex#replace_eval ` in the next step you should look here https://github.com/cedlemo/ruby-gnome2/blob/f38f53d2032e0df457d88a2c2d1a4f2f65b2d9e9/glib2/ext/glib2/rbglib_regex.c#L212 and https://github.com/cedlemo/ruby-gnome2/blob/f38f53d2032e0df457d88a2c2d1a4f2f65b2d9e9/glib2/ext/glib2/rbglib_regex.c#L254 . This is How I plan to implement it. Tell me if there is something wrong with this.