### PR TITLE
Glib2 match info partial match

### DIFF
--- a/glib2/ext/glib2/rbglib_matchinfo.c
+++ b/glib2/ext/glib2/rbglib_matchinfo.c
@@ -48,6 +48,12 @@ rg_match_count(VALUE self)
     return INT2NUM(g_match_info_get_match_count(_SELF(self)));
 }
 
+static VALUE
+rg_partial_match_p(VALUE self)
+{
+    return CBOOL2RVAL(g_match_info_is_partial_match(_SELF(self)));
+}
+
 void
 Init_glib_matchinfo(void)
 {
@@ -58,4 +64,5 @@ Init_glib_matchinfo(void)
     RG_DEF_METHOD(string, 0);
     RG_DEF_METHOD_P(matches, 0);
     RG_DEF_METHOD(match_count, 0);
+    RG_DEF_METHOD_P(partial_match, 0);
 }

--- a/glib2/test/test-match-info.rb
+++ b/glib2/test/test-match-info.rb
@@ -15,15 +15,27 @@
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 
 class TestMatchInfo < Test::Unit::TestCase
-    def test_string
-      regex = GLib::Regex.new("[A-Z]+")
-      match_info = regex.match("abc def")
-      assert_equal("abc def", match_info.string)
-    end
+  def test_string
+    regex = GLib::Regex.new("[A-Z]+")
+    match_info = regex.match("abc def")
+    assert_equal("abc def", match_info.string)
+  end
 
-    def test_regex
-      regex = GLib::Regex.new("[A-Z]+")
-      match_info = regex.match("abc def")
-      assert_equal("[A-Z]+", match_info.regex.pattern)
+  def test_regex
+    regex = GLib::Regex.new("[A-Z]+")
+    match_info = regex.match("abc def")
+    assert_equal("[A-Z]+", match_info.regex.pattern)
+  end
+
+  def test_partial_match
+    flags = GLib::RegexMatchFlags::PARTIAL_SOFT
+    regex = GLib::Regex.new("jan")
+    match_info = regex.match_all("ja", :match_options => flags)
+    assert do
+      !match_info.matches?
     end
+    assert do
+      match_info.partial_match?
+    end
+  end
 end


### PR DESCRIPTION
Here is the how I visualize what I will do next:

*    `GLib::MatchInfo#expand_references` for `g_match_info_expand_references`


For the different fetch functions, I first thought to make just one method that would have an hash parameter like we did previously for `GLib::Regex#match` for exeample, but I didn't think that it would be a good idea.
 
*    `GLib::MatchInfo#fetch` for `g_match_info_fetch`
*    `GLib::MatchInfo#fetch_named` for `g_match_info_fetch_named`
*    `GLib::MatchInfo#fetch_pos` for `g_match_info_fetch_pos`
*    `GLib::MatchInfo#fetch_named_pos` for `g_match_info_fetch_named_pos`
*    `GLib::MatchInfo#next` for `g_match_info_next`
*    `GLib::MatchInfo#fetch_all` for `g_match_info_fetch_all`

Tell me if you see a better way to do this.
