### PR TITLE
Gtk3 sample gtk demo pixbufs rb

### DIFF
--- a/gtk3/sample/gtk-demo/TODO
+++ b/gtk3/sample/gtk-demo/TODO
@@ -50,7 +50,7 @@ overlay.c               ok              ok
 overlay2.c              ok              ok
 panes.c                 ok              ok
 pickers.c               ok              ok
-pixbufs.c               ok              no
+pixbufs.c               ok              ok
 popover.c               ok              ok
 printing.c              ok              ok
 revealer.c              ok              ok


### PR DESCRIPTION
If you look at the line 119, in the C version they use `gdk_pixbuf_new_from_resource` I was not able to create directly a `Gdk::Pixbuf` from a resource so I created a `Gtk::Image` and use the `Gyk::Image#pixbuf` method.

Tell me if think that we should use `Gdk::Pixbuf.new(:resource => path)`