### PR TITLE
Enable working tests for gsf and goffice

### DIFF
--- a/goffice/test/run-test.rb
+++ b/goffice/test/run-test.rb
@@ -22,6 +22,7 @@ ruby_gnome2_base = File.expand_path(ruby_gnome2_base)
 gobject_introspection_base = File.join(ruby_gnome2_base, "gobject-introspection")
 gio2_base = File.join(ruby_gnome2_base, "gio2")
 gsf_base = File.join(ruby_gnome2_base, "gsf")
+gdk3_base = File.join(ruby_gnome2_base, "gdk3")
 gtk3_base = File.join(ruby_gnome2_base, "gtk3")
 goffice_base = File.join(ruby_gnome2_base, "goffice")
 
@@ -29,6 +30,7 @@ modules = [
   [gobject_introspection_base, "gobject-introspection"],
   [gio2_base, "gio2"],
   [gsf_base, "gsf"],
+  [gdk3_base, "gdk3"],
   [gtk3_base, "gtk3"],
   [goffice_base, "goffice"]
 ]

--- a/goffice/test/run-test.rb
+++ b/goffice/test/run-test.rb
@@ -28,7 +28,7 @@ goffice_base = File.join(ruby_gnome2_base, "goffice")
 modules = [
   [gobject_introspection_base, "gobject-introspection"],
   [gio2_base, "gio2"],
-  [gsf_base, "gsf"]
+  [gsf_base, "gsf"],
   [gtk3_base, "gtk3"],
   [goffice_base, "goffice"]
 ]

--- a/goffice/test/run-test.rb
+++ b/goffice/test/run-test.rb
@@ -42,6 +42,9 @@ modules.each do |target, module_name|
   $LOAD_PATH.unshift(File.join(target, "lib"))
 end
 
+$LOAD_PATH.unshift(File.join(goffice_base, "test"))
+require "goffice-test-utils"
+
 require "goffice"
 
 exit Test::Unit::AutoRunner.run(true, File.join(goffice_base, "test"))

--- a/gsf/test/run-test.rb
+++ b/gsf/test/run-test.rb
@@ -38,6 +38,9 @@ modules.each do |target, module_name|
   $LOAD_PATH.unshift(File.join(target, "lib"))
 end
 
+$LOAD_PATH.unshift(File.join(gsf_base, "test"))
+require "gsf-test-utils"
+
 require "gsf"
 
 exit Test::Unit::AutoRunner.run(true, File.join(gsf_base, "test"))

--- a/travis-before-script.sh
+++ b/travis-before-script.sh
@@ -34,5 +34,7 @@ sudo apt-get install -qq -y \
     gir1.2-webkit-1.0 \
     gir1.2-webkit-3.0 \
     gir1.2-webkit2-3.0 \
+    gir1.2-gsf-1 \
+    gir1.2-goffice-0.10 \
     gnome-icon-theme \
     dbus-x11


### PR DESCRIPTION
Follows up #772, #774.
But for now, `gsf` and `goffice` have no test.
Them test will be failure though.