### PR TITLE
Append the gsf, gnm and goffice in the Rakefile

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -174,6 +174,9 @@ gnome2_packages = gtk2_packages + gtk3_packages + [
   "webkit-gtk",
   "webkit-gtk2",
   "webkit2-gtk",
+  "gsf",
+  "goffice",
+  "gnm"
 ]
 gnome2_packages = gnome2_packages.uniq
 


### PR DESCRIPTION
I was not able to build the gem files with `rake gem:build` so I modified the main Rakefile. I hope this is the good way to do this.