### PR TITLE
Gdk pixbuf2 backward compatibility

### DIFF
--- a/gdk_pixbuf2/lib/gdk_pixbuf2/pixbuf.rb
+++ b/gdk_pixbuf2/lib/gdk_pixbuf2/pixbuf.rb
@@ -2,8 +2,57 @@ module GdkPixbuf
   class Pixbuf
     alias_method :initialize_raw, :initialize
 
-    def initialize(options = {})
-      colorspace = options[:colorspace] || GdkPixbuf::Colorspace::RGB 
+    def initialize(*args)
+      case args.size
+      when 1
+        if args[0].class == Hash
+          initialize_with_hash(args[0])
+        elsif args[0].class == String
+          puts deprecated_usage_message
+          initialize_raw(args[0])
+        elsif args[0].class == Array
+          puts deprecated_usage_message
+          initialize_new_from_xpm_data(args[0])
+        else
+          puts "Wrong type of arguments"
+          puts deprecated_usage_message
+        end
+      when 2
+        # initialize_from_inline_data is deprecated
+      when 3
+        puts deprecated_usage_message
+        initialize_new_from_file_at_size(*args)
+      when 4
+        puts deprecated_usage_message
+        initialize_new_from_file_at_scale(*args)
+      when 5
+        if args[0].class == GdkPixbuf::Pixbuf
+          puts deprecated_usage_message
+          initialize_new_from_subpixbuf(*args)
+        elsif args[0].class == GdkPixbuf::Colorspace # No other value
+          puts deprecated_usage_message
+          initialize_new(*args)
+        else
+          puts "Wrong type of 1st argument, must be a Pixbuf or Colorspace"
+        end
+      when 7
+        puts deprecated_usage_message
+        initialize_new_from_data(*args)
+      else
+        puts "Wrong number of arguments"
+        puts deprecated_usage_message
+      end
+    end
+
+    def deprecated_usage_message
+      "Please use the hash form for the arguments :colorspace, :has_alpha, " +
+      ":bits_per_sample, :row_stride, :src_x, :src_y, :src_pixbuf, :data, " +
+      ":bytes, :xpm, :file, :stream, :resource, :width, :height, :scale, " +
+      ":preserve_aspect_ration"
+    end
+
+    def initialize_with_hash(options)
+      colorspace = options[:colorspace] || GdkPixbuf::Colorspace::RGB
       has_alpha = options[:has_alpha] || false
       bits_per_sample = options[:bits_per_sample] || 8
       row_stride = options[:row_stride] || 0
@@ -21,31 +70,31 @@ module GdkPixbuf
       size = true if width && height
       scale = options[:scale] || nil
       preserve_aspect_ratio = options[:preserve_aspect_ratio] || true
-      
-      
+
+
       if file && size && scale
-        initialize_new_from_file_at_scale(file, width, height, 
+        initialize_new_from_file_at_scale(file, width, height,
                                           preserve_aspect_ratio)
       elsif file && size && !scale
         initialize_new_from_file_at_size(file, width, height)
-      elsif file && !size 
+      elsif file && !size
         initialize_new_from_file(file)
       elsif resource && size && scale
         initialize_new_from_resource_at_scale(resource, width, height)
       elsif resource && !scale
         initialize_new_from_resource(resource)
-      elsif data && size 
+      elsif data && size
         initialize_new_from_data(colorspace, has_alpha, bits_per_sample,
                                  width, height, row_stride)
       elsif bytes && size
          initialize_new_from_bytes(colorspace, has_alpha, bits_per_sample,
                                    width, height, row_stride)
-       
+
       elsif xpm
-        initialize_new_from_xpm(xpm)
+        initialize_new_from_xpm_data(xpm)
       elsif src_pixbuf && size
         initialize_new_from_subpixbuf(src_pixbuf, src_x, src_y, width, height)
-      elsif size 
+      elsif size
         initialize_raw(colorspace, has_alpha, bits_per_sample, width, height)
       else
         puts "Please provide a width and an height"

--- a/gdk_pixbuf2/test/test-gdk_pixbuf.rb
+++ b/gdk_pixbuf2/test/test-gdk_pixbuf.rb
@@ -2,10 +2,10 @@ class TestGdkPixbuf < Test::Unit::TestCase
   include GdkPixbufTestUtils
 
   sub_test_case(".new") do
-    test "basic" do
+    test "basic hash form" do
       colorspace =  GdkPixbuf::Colorspace::RGB
       width = 100
-      height = 100 
+      height = 100
       has_alpha = true
       bits_per_sample = 8
       pixbuf = GdkPixbuf::Pixbuf.new(:colorspace => colorspace,
@@ -19,9 +19,56 @@ class TestGdkPixbuf < Test::Unit::TestCase
       assert_equal(has_alpha, pixbuf.has_alpha?)
       assert_equal(bits_per_sample, pixbuf.bits_per_sample)
     end
-    
-    test "from_file" do
-      pixbuf = GdkPixbuf::Pixbuf.new(:file => fixture_path("gnome-logo-icon.png"))
+
+    test "basic legacy form" do
+      colorspace =  GdkPixbuf::Colorspace::RGB
+      width = 100
+      height = 100
+      has_alpha = true
+      bits_per_sample = 8
+      pixbuf = GdkPixbuf::Pixbuf.new(colorspace, has_alpha, bits_per_sample,
+                                     width, height)
+      assert_equal(colorspace, pixbuf.colorspace)
+      assert_equal(width, pixbuf.width)
+      assert_equal(height, pixbuf.height)
+      assert_equal(has_alpha, pixbuf.has_alpha?)
+      assert_equal(bits_per_sample, pixbuf.bits_per_sample)
+    end
+
+    test "from_file hash form" do
+      filename = fixture_path("gnome-logo-icon.png")
+      pixbuf = GdkPixbuf::Pixbuf.new(:file => filename)
+      assert_equal(GdkPixbuf::Colorspace::RGB, pixbuf.colorspace)
+    end
+
+    test "from_file legacy form" do
+      pixbuf = GdkPixbuf::Pixbuf.new(fixture_path("gnome-logo-icon.png"))
+      assert_equal(GdkPixbuf::Colorspace::RGB, pixbuf.colorspace)
+    end
+
+    r_xpm = [
+       "10 10 3 1",
+       "   c None",
+       ".  c #FE0B0B",
+       "+  c #FFFFFF",
+       "+.......++",
+       "+..    ..+",
+       "+..    ..+",
+       "+..   ...+",
+       "+.......++",
+       "+.....++++",
+       "+..++..+++",
+       "+..++...++",
+       "+..+++...+",
+       "+..++++..+"]
+
+    test "from_xpm legacy form" do
+      pixbuf = GdkPixbuf::Pixbuf.new(r_xpm)
+      assert_equal(GdkPixbuf::Colorspace::RGB, pixbuf.colorspace)
+    end
+
+    test "from_xpm hash form" do
+      pixbuf = GdkPixbuf::Pixbuf.new(:xpm => r_xpm)
       assert_equal(GdkPixbuf::Colorspace::RGB, pixbuf.colorspace)
     end
   end


### PR DESCRIPTION
I hope this is what you expected. Ifollowed the C code in rbgdk-pixbuf.c. All the tests are not done yet but I prefer to be sure that my work correspond to what you asked me.

One question about the inclusion of Gdk_pixbuf2, the only way to make it works was to do something like this : 

```ruby
module Gdk
    class Pixbuf < GdkPixbuf::Pixbuf
    end
end
```
Is there any "metprogramming" tricks that can try to load from  GdkPixbuf all the non found constants or methods of Gdk like with `method_missing`. 