### PR TITLE
Include GdkPixbuf::Pixbuf into Gdk

### DIFF
--- a/gdk3/lib/gdk3.rb
+++ b/gdk3/lib/gdk3.rb
@@ -36,6 +36,8 @@ module Gdk
   class Error < StandardError
   end
 
+  include GdkPixbuf
+
   class << self
     def const_missing(name)
       init


### PR DESCRIPTION
With this, all is working fine. What do you want me to do next?

Continue the gtk-demos or finish the tests for gdk_pixbufs. I would prefer finish the tests for the implemented options and functions of GdkPixbuf.

 