### PR TITLE
gtk3 sample: Fix error when clicking invalid node

### DIFF
--- a/gtk3/sample/gtk-demo/main.rb
+++ b/gtk3/sample/gtk-demo/main.rb
@@ -345,6 +345,7 @@ class Demo < Gtk::Application
     @treeview.signal_connect "row-activated" do |_tree_view, path, _column|
       iter = model.get_iter(path)
       filename = iter[1]
+      next unless filename
       iter[2] = Pango::FontDescription::STYLE_ITALIC
       demo = run_demo_from_file(filename, windows.first)
       demo.signal_connect "destroy" do


### PR DESCRIPTION
When double-clicking some nodes which parent of other nodes(such as "Entry", "Icon View"), 
demo code put errors and stop itself.
```
main.rb:128:in `basename': no implicit conversion of nil into String
         from main.rb:128:in `get_demo_name_from_filename'
         from main.rb:132:in `get_module_name_from_filename'
         from main.rb:176:in `run_demo_from_file'
         from main.rb:350:in `block in run_application'
         from /home/tsr/.gem/ruby/2.3.0/gems/gobject-introspection-3.0.9/lib/gobject-introspection/loader.rb:564:in `invoke'
         from /home/tsr/.gem/ruby/2.3.0/gems/gobject-introspection-3.0.9/lib/gobject-introspection/loader.rb:564:in `block in define_method'
         from main.rb:489:in `<main>'
main.rb: [BUG] Segmentation fault at 0x00000000000010
ruby 2.3.0p0 (2015-12-25) [x86_64-linux-gnu]
```
Checking filename was missing, so I have fixed it.