### PR TITLE
Segmentation fault in Poppler::Page#text_layout.

### DIFF
--- a/poppler/ext/poppler/rbpoppler-page.c
+++ b/poppler/ext/poppler/rbpoppler-page.c
@@ -205,16 +205,15 @@ rg_text_layout(VALUE self)
     guint n_rectangles;
 
     if (poppler_page_get_text_layout(SELF(self), &rectangles, &n_rectangles)) {
-        VALUE *rb_list, *p;
         VALUE ary;
         guint i;
-        rb_list = p = ALLOC_N(VALUE, n_rectangles);
-        for (i = 0; i < n_rectangles; i++, p++) {
-            *p = POPPLERRECTANGLE2RVAL(&rectangles[i]);
+        ary = rb_ary_new2((long)n_rectangles);
+        for (i = 0; i < n_rectangles; i++) {
+            rb_ary_store(ary, (long)i,
+                         POPPLERRECTANGLE2RVAL(&(rectangles[i])));
         }
-        ary = rb_ary_new4(n_rectangles, rb_list);
-        free(rb_list);
-        free(rectangles);
+
+        g_free(rectangles);
         return ary;
     } else {
         return Qnil;

--- a/poppler/test/test_page.rb
+++ b/poppler/test/test_page.rb
@@ -30,6 +30,24 @@ class TestPage < Test::Unit::TestCase
     assert_kind_of(Poppler::Annotation, mapping.annotation)
   end
 
+  def test_text_layout
+    if later_version?(0, 16, 0)
+      tmp_stdout = $stdout
+      $stdout    = open('/dev/null', 'w')
+        document = Poppler::Document.new(form_pdf)
+        page = document[0]
+
+        # segmentation fault on poppler.gem 3.0.8
+        10.times {|i|
+          puts page.text_layout[0]
+        }
+      $stdout.close
+      $stdout = tmp_stdout
+
+      assert_equal(true, true)
+    end
+  end
+
   private
   def find_first_image_mapping(document)
     document.each do |page|


### PR DESCRIPTION
Hi.
I used poppler.gem 3.0.8 in Mac OS X 10.10.5, ruby version is 2.2.2 and 2.3.1. And I got segmentation fault when I access several times to the array of PopplerRectangle objects via Page#text_layout.

So I rewrote text_layout method in a simple way. Could you please see my modification and test case?
Thanks.