### PR TITLE
Remove conditionnal macro based on HAVE_RUBY_ENCODING_H

### DIFF
--- a/glib2/ext/glib2/rbgutil.c
+++ b/glib2/ext/glib2/rbgutil.c
@@ -116,10 +116,8 @@ rbgutil_generic_gtype(VALUE self)
 VALUE
 rbgutil_string_set_utf8_encoding(VALUE string)
 {
-#ifdef HAVE_RUBY_ENCODING_H
     if (!NIL_P(string))
         rb_enc_associate(string, rb_utf8_encoding());
-#endif
     return string;
 }
 

--- a/glib2/ext/glib2/rbgutil.h
+++ b/glib2/ext/glib2/rbgutil.h
@@ -24,9 +24,7 @@
 
 #include <glib-object.h>
 #include "ruby.h"
-#ifdef HAVE_RUBY_ENCODING_H
-#  include <ruby/encoding.h>
-#endif
+#include <ruby/encoding.h>
 #include "rbglib.h"
 #include "rbgutil_list.h"
 #include "rbgutildeprecated.h"


### PR DESCRIPTION
If I understand well the ruby/encoding.h has been introduced with ruby 1.9 ~ so you want to remove the if close because you support only ruby version (> 2.1).

I hope it is what you wanted in #782.