### PR TITLE
gdk_pixbuf2: Fix runtime dependency

### DIFF
--- a/gdk_pixbuf2/Rakefile
+++ b/gdk_pixbuf2/Rakefile
@@ -23,6 +23,7 @@ package_task = GNOME2::Rake::PackageTask.new do |package|
   package.summary = "Ruby/GdkPixbuf2 is a Ruby binding of GdkPixbuf-2.x."
   package.description = "Ruby/GdkPixbuf2 is a Ruby binding of GdkPixbuf-2.x."
   package.dependency.gem.runtime = [
+    "gobject-introspection",
     "gio2",
   ]
   package.windows.packages = []


### PR DESCRIPTION
gdk_pixbuf2 also requires 'gobject-introspection' gem.

Follows up https://github.com/ruby-gnome2/ruby-gnome2/commit/5cb0def4dad4439b9e4aea431578dfc7b98a2883.
I've also encountered to the same issue: https://github.com/ruby-gnome2/ruby-gnome2/issues/900#issuecomment-244742030.

