### PR TITLE
do not try to run a demo when the user provide a bad demo name

### DIFF
--- a/gtk3/sample/gtk-demo/main.rb
+++ b/gtk3/sample/gtk-demo/main.rb
@@ -362,7 +362,7 @@ class Demo < Gtk::Application
 
     if @options[:name]
       filename = get_demo_filename_from_name(@options[:name])
-      run_demo_from_file(filename, windows.first)
+      run_demo_from_file(filename, windows.first) if filename
     end
 
     if @options[:autoquit]


### PR DESCRIPTION
this prevent to try to run a demo when a user do `main.rb -r a_bad_demo_name`. 