### PR TITLE
Force LC_NUMERIC to C when gtk3 is initialized

### DIFF
--- a/gtk3/ext/gtk3/rb-gtk3.c
+++ b/gtk3/ext/gtk3/rb-gtk3.c
@@ -19,6 +19,7 @@
  */
 
 #include "rb-gtk3-private.h"
+#include <locale.h>
 
 static ID id_call;
 static VALUE cGdkAtom;
@@ -640,4 +641,5 @@ Init_gtk3(void)
     rbgtk3_widget_init();
 
     rbgobj_boxed_not_copy_obj(GTK_TYPE_SELECTION_DATA);
+    setlocale(LC_NUMERIC, "C");
 }


### PR DESCRIPTION
#928
#943

tested with : 

``` ruby
require 'ffi'


module Local
  extend FFI::Library
  ffi_lib FFI::Library::LIBC
  attach_function :setlocale, [:int, :string], :string
end


defs = %w[LC_CTYPE LC_NUMERIC LC_TIME LC_COLLATE LC_MONETARY LC_MESSAGES LC_ALL LC_PAPER LC_NAME LC_ADDRESS LC_TELEPHONE LC_MEASUREMENT LC_IDENTIFICATION]

puts "\nbefore GTK3\n"
defs.each_with_index { |d,i| puts "%s: %s\n" % [d,Local.setlocale( i, nil)] }
require 'gtk3'
Gtk::Label.new
puts "\nafter GTK3\n"
defs.each_with_index { |d,i| puts "%s: %s\n" % [d,Local.setlocale( i, nil)] }
```

Results : 

```
ruby test_setlocale_C.rb 

before GTK3
LC_CTYPE: fr_FR.utf8
LC_NUMERIC: C
LC_TIME: C
LC_COLLATE: C
LC_MONETARY: C
LC_MESSAGES: C
LC_ALL: LC_CTYPE=fr_FR.utf8;LC_NUMERIC=C;LC_TIME=C;LC_COLLATE=C;LC_MONETARY=C;LC_MESSAGES=C;LC_PAPER=C;LC_NAME=C;LC_ADDRESS=C;LC_TELEPHONE=C;LC_MEASUREMENT=C;LC_IDENTIFICATION=C
LC_PAPER: C
LC_NAME: C
LC_ADDRESS: C
LC_TELEPHONE: C
LC_MEASUREMENT: C
LC_IDENTIFICATION: C

after GTK3
LC_CTYPE: fr_FR.utf8
LC_NUMERIC: C
LC_TIME: fr_FR.UTF-8
LC_COLLATE: fr_FR.utf8
LC_MONETARY: fr_FR.UTF-8
LC_MESSAGES: fr_FR.utf8
LC_ALL: LC_CTYPE=fr_FR.utf8;LC_NUMERIC=C;LC_TIME=fr_FR.UTF-8;LC_COLLATE=fr_FR.utf8;LC_MONETARY=fr_FR.UTF-8;LC_MESSAGES=fr_FR.utf8;LC_PAPER=fr_FR.UTF-8;LC_NAME=fr_FR.utf8;LC_ADDRESS=fr_FR.utf8;LC_TELEPHONE=fr_FR.utf8;LC_MEASUREMENT=fr_FR.UTF-8;LC_IDENTIFICATION=fr_FR.utf8
LC_PAPER: fr_FR.UTF-8
LC_NAME: fr_FR.utf8
LC_ADDRESS: fr_FR.utf8
LC_TELEPHONE: fr_FR.utf8
LC_MEASUREMENT: fr_FR.UTF-8
LC_IDENTIFICATION: fr_FR.utf8
```

Seems Ok.
