### PR TITLE
Ignore build time-stamps.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,5 @@ mkmf.log
 /Gemfile.lock
 /Gemfile.local
 /build/.vagrant/
+*/.RUBYLIBDIR*.time
+*/.RUBYARCHDIR.time


### PR DESCRIPTION
Ignore build-time stamps for git, which are created by a extconf.rb / make run.