### PR TITLE
Gtk3 sample gtk demo todo checks part4

### DIFF
--- a/gtk3/sample/gtk-demo/TODO
+++ b/gtk3/sample/gtk-demo/TODO
@@ -1,5 +1,5 @@
 # Ruby version : is there already a ruby version of the demo
-# Updated 3.20 : if there is a ruby version is it udapted to 3.19
+# Updated 3.22 : if there is a ruby version is it udapted to 3.22
 #
 C version             Ruby version    Updated 3.22
 assistant.c             ok              ok
@@ -35,23 +35,25 @@ overlay.c               ok              ok
 overlay2.c              ok              ok
 panes.c                 ok              ok
 pickers.c               ok              ok
-pixbufs.c               ok              no
-popover.c               ok              no
+pixbufs.c               ok              ok
+popover.c               ok              ok
 printing.c              ok              ok
-revealer.c              ok              no
-rotated_text.c          ok              no
+revealer.c              ok              ok
+rotated_text.c          ok              ok
 scale.c                 ok              ok
-search_entry.c          ok              no
-search_entry2.c         ok              no
-sidebar.c               ok              no
-sizegroup.c             ok              no
+search_entry.c          ok              ok
+search_entry2.c         ok              ok
+sidebar.c               ok              ok
+sizegroup.c             ok              ok
 spinbutton.c            ok              ok
-spinner.c               ok              no
+spinner.c               ok              ok
 stack.c                 ok              ok
-textmask.c              ok              no
-textscroll.c            ok              no
-theming_style_classes.c ok              no
-transparent.c           ok              no
+textmask.c              ok              ok
+textscroll.c            ok              ok
+theming_style_classes.c ok              ok
+transparent.c           ok              ok
+
+Remains :
 
 application.c           no              no
 changedisplay.c         ok              no

--- a/gtk3/sample/gtk-demo/popover.rb
+++ b/gtk3/sample/gtk-demo/popover.rb
@@ -13,7 +13,7 @@ class PopoverDemo
     @window = Gtk::Window.new(:toplevel)
     @window.screen = main_window.screen
     box = Gtk::Box.new(:vertical, 24)
-    box.border_width = 24
+    box.margin = 24
     @window.add(box)
 
     widget = add_toggle_button_with_popover
@@ -39,7 +39,7 @@ class PopoverDemo
     popover = Gtk::Popover.new(parent)
     popover.position = pos
     popover.add(child)
-    popover.border_width = 6
+    child.margin = 6
     child.show
     popover
   end
@@ -51,11 +51,6 @@ class PopoverDemo
     content.parent.remove(content)
     window.destroy
     popover = create_popover(parent, content, pos)
-    popover.set_size_request(200, -1)
-    popover.vexpand = true
-    popover.margin_start = 10
-    popover.margin_end = 10
-    popover.margin_bottom = 10
     popover
   end
 

--- a/gtk3/sample/gtk-demo/revealer.rb
+++ b/gtk3/sample/gtk-demo/revealer.rb
@@ -45,8 +45,10 @@ class RevealerDemo
       revealer.reveal_child = true
 
       revealer.signal_connect "notify::child-revealed" do |widget|
-        revealed = widget.child_revealed?
-        widget.reveal_child = revealed
+        if widget.mapped?
+          revealed = widget.child_revealed?
+          widget.reveal_child = !revealed
+        end
       end
 
       @count += 1

--- a/gtk3/sample/gtk-demo/search_entry.rb
+++ b/gtk3/sample/gtk-demo/search_entry.rb
@@ -40,7 +40,7 @@ class SearchEntryDemo
   def initialize_box
     @vbox = Gtk::Box.new(:vertical, 5)
     @window.add(@vbox)
-    @vbox.border_width = 5
+    @vbox.margin = 5
 
     label = Gtk::Label.new("")
     label.markup = "Search entry demo"
@@ -48,7 +48,6 @@ class SearchEntryDemo
 
     @hbox = Gtk::Box.new(:horizontal, 10)
     @vbox.pack_start(@hbox, :expand => true, :fill => true, :padding => 0)
-    @hbox.border_width = 0
   end
 
   def initialize_entry

--- a/gtk3/sample/gtk-demo/search_entry2.rb
+++ b/gtk3/sample/gtk-demo/search_entry2.rb
@@ -61,7 +61,6 @@ class SearchEntry2Demo
   def initialize_vbox
     @vbox = Gtk::Box.new(:vertical, 0)
     @window.add(@vbox)
-    @vbox.border_width = 0
   end
 
   def initialize_help_label
@@ -81,7 +80,6 @@ class SearchEntry2Demo
   def initialize_result_hbox
     hbox = Gtk::Box.new(:horizontal, 10)
     @vbox.pack_start(hbox, :expand => true, :fill => true, :padding => 0)
-    hbox.border_width = 0
 
     # Result
     label = Gtk::Label.new("Result:")
@@ -101,7 +99,6 @@ class SearchEntry2Demo
   def initialize_signal_hbox
     hbox = Gtk::Box.new(:horizontal, 10)
     @vbox.pack_start(hbox, :expand => true, :fill => true, :padding => 0)
-    hbox.border_width = 0
 
     label = Gtk::Label.new("Signal:")
     label.xalign = 0.0

--- a/gtk3/sample/gtk-demo/sizegroup.rb
+++ b/gtk3/sample/gtk-demo/sizegroup.rb
@@ -29,7 +29,7 @@ class SizegroupDemo
 
     @vbox = Gtk::Box.new(:vertical, 5)
     @window.add(@vbox)
-    @vbox.border_width = 5
+    @vbox.margin = 5
 
     size_group = Gtk::SizeGroup.new(:horizontal)
 
@@ -74,7 +74,7 @@ class SizegroupDemo
     @vbox.pack_start(frame, :expand => false, :fill => false, :padding => 0)
 
     table = Gtk::Grid.new
-    table.set_border_width(5)
+    table.margin = 5
     table.set_row_spacing(5)
     table.set_column_spacing(10)
     frame.add(table)

--- a/gtk3/sample/gtk-demo/sizegroup.rb
+++ b/gtk3/sample/gtk-demo/sizegroup.rb
@@ -46,6 +46,7 @@ class SizegroupDemo
     # And a check button to turn grouping on and off
     check_button = Gtk::CheckButton.new("_Enable grouping")
     check_button.use_underline = true
+    check_button.active = true
     @vbox.pack_start(check_button,
                      :expand => false, :fill => false, :padding => 0)
 

--- a/gtk3/sample/gtk-demo/sizegroup.rb
+++ b/gtk3/sample/gtk-demo/sizegroup.rb
@@ -45,15 +45,15 @@ class SizegroupDemo
 
     # And a check button to turn grouping on and off
     check_button = Gtk::CheckButton.new("_Enable grouping")
-    check_button.set_use_underline(true)
+    check_button.use_underline = true
     @vbox.pack_start(check_button,
                      :expand => false, :fill => false, :padding => 0)
 
     check_button.signal_connect("toggled") do |widget|
       if widget.active?
-        size_group.set_mode(:horizontal)
+        size_group.mode = :horizontal
       else
-        size_group.set_mode(:none)
+        size_group.mode = :none
       end
     end
   end
@@ -75,23 +75,23 @@ class SizegroupDemo
 
     table = Gtk::Grid.new
     table.margin = 5
-    table.set_row_spacing(5)
-    table.set_column_spacing(10)
+    table.row_spacing = 5
+    table.column_spacing = 10
     frame.add(table)
     table
   end
 
   def add_row(table, row, size_group, label_text, options)
     label = Gtk::Label.new(label_text, :use_underline => true)
-    label.set_halign(:start)
-    label.set_valign(:baseline)
-    label.set_hexpand(true)
+    label.halign = :start
+    label.valign = :baseline
+    label.hexpand = true
     table.attach(label, 0, row, 1, 1)
 
     combo_box = create_combo_box(options)
-    label.set_mnemonic_widget(combo_box)
-    combo_box.set_halign(:end)
-    combo_box.set_valign(:baseline)
+    label.mnemonic_widget = combo_box
+    combo_box.halign = :end
+    combo_box.valign = :baseline
     size_group.add_widget(combo_box)
     table.attach(combo_box, 1, row, 1, 1)
   end
@@ -101,7 +101,7 @@ class SizegroupDemo
     options.each do |o|
       combo_box.append_text(o)
     end
-    combo_box.set_active(0)
+    combo_box.active = 0
     combo_box
   end
 end

--- a/gtk3/sample/gtk-demo/spinner.rb
+++ b/gtk3/sample/gtk-demo/spinner.rb
@@ -53,7 +53,7 @@ class SpinnerDemo
     @vbox = Gtk::Box.new(:vertical, 5)
     content_area.pack_start(@vbox,
                             :expand => true, :fill => true, :padding => 0)
-    @vbox.border_width = 5
+    @vbox.margin = 5
   end
 
   def initialize_sensitive_box

--- a/gtk3/sample/gtk-demo/theming_style_classes.rb
+++ b/gtk3/sample/gtk-demo/theming_style_classes.rb
@@ -36,7 +36,6 @@ class ThemingStyleClassesDemo
     @window.screen = main_window.screen
     @window.title = "Style Classes"
     @window.resizable = false
-    @window.border_width = 12
 
     builder = Gtk::Builder.new(:resource => "/theming_style_classes/theming.ui")
     grid = builder["grid"]

--- a/gtk3/sample/gtk-demo/transparent.rb
+++ b/gtk3/sample/gtk-demo/transparent.rb
@@ -16,7 +16,6 @@ class TransparentDemo
     @window.screen = main_window.screen
     @window.set_default_size(450, 450)
     @window.title = "Transparency"
-    @window.border_width = 0
 
     view = Gtk::TextView.new
     sw = Gtk::ScrolledWindow.new


### PR DESCRIPTION
Just a recap:

*  all the demos already done has been updated to 3.22
*  it remains to adapt the following demos: 
    *  application.c 
    *  changedisplay.c 
    *  combobox.c   
    *  css_blendmodes.c	
    *  event_axes.c       
    *  fishbowl.c	
    *  flowbox.c             
    *  foreigndrawing  
    *  gestures.c        
    *  images.c     
    *  shortcuts.c     
    *  textview.c     
    *  toolpalette.c   
    *  tree_store.c 
*  the main.rb file must be improved in order to display in the left all the data files (code, informations , ui files or open gl shaders) related to the selected demo.
*  If I well understood, all the gtk3 code after 3.22 will not really change and they start to work on gtk4 (correct me if I am wrong).


