### PR TITLE
Add missing braces

### DIFF
--- a/pango/lib/pango/font-description.rb
+++ b/pango/lib/pango/font-description.rb
@@ -21,7 +21,7 @@ module Pango
         if description
           from_string(description)
         else
-          super
+          super()
         end
       end
     end


### PR DESCRIPTION
Without it a call to
Pango::FontDescription.new()
without parameters will fail.