### PR TITLE
Fix check for inheritance from GLib::Instantiatable

### DIFF
--- a/glib2/ext/glib2/rbgobj_typeinterface.c
+++ b/glib2/ext/glib2/rbgobj_typeinterface.c
@@ -1,6 +1,6 @@
 /* -*- c-file-style: "ruby"; indent-tabs-mode: nil -*- */
 /*
- *  Copyright (C) 2011  Ruby-GNOME2 Project Team
+ *  Copyright (C) 2011,2017  Ruby-GNOME2 Project Team
  *  Copyright (C) 2002-2006  Ruby-GNOME2 Project Team
  *  Copyright (C) 2002,2003  Masahiro Sakai
  *
@@ -30,7 +30,7 @@ VALUE RG_TARGET_NAMESPACE;
 static VALUE
 rg_append_features(G_GNUC_UNUSED VALUE self, VALUE klass)
 {
-    if (!rb_obj_is_kind_of(klass, cInstantiatable))
+    if (rb_class_inherited_p(klass, cInstantiatable) != Qtrue)
         rb_raise(rb_eTypeError, "Not a subclass of GLib::Instantiatable");
     return rb_call_super(1, &klass);
 }

--- a/glib2/test/test-typeinterface.rb
+++ b/glib2/test/test-typeinterface.rb
@@ -1,0 +1,32 @@
+# Copyright (C) 2017  Ruby-GNOME2 Project Team
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+
+require 'test/unit'
+require 'glib2'
+
+class TestTypeInterface < Test::Unit::TestCase
+  def test_require_instantiatable_superclass
+    bad_class = Class.new
+    assert_raises do
+      bad_class.class_eval { include GLib::TypePlugin }
+    end
+
+    good_class = Class.new GLib::Object
+    assert_nothing_raised do
+      good_class.class_eval { include GLib::TypePlugin }
+    end
+  end
+end


### PR DESCRIPTION
This fixes the check that Interface modules do so they can only be included in classes that inherit from `GLib::Instantiatable`.