### PR TITLE
Ensure that there is no crash when the demo does not returns a widget

### DIFF
--- a/gtk3/sample/gtk-demo/main.rb
+++ b/gtk3/sample/gtk-demo/main.rb
@@ -369,9 +369,11 @@ class Demo < Gtk::Application
         puts("failed to run demo: #{filename}")
         report_error(error)
       else
-        iter[2] = Pango::Style::ITALIC
-        demo.signal_connect "destroy" do
-          iter[2] = Pango::Style::NORMAL
+        if demo.respond_to? :signal_connect
+          iter[2] = Pango::Style::ITALIC
+          demo.signal_connect "destroy" do
+            iter[2] = Pango::Style::NORMAL
+          end
         end
       end
     end


### PR DESCRIPTION
Since `GtkPrintOperation` is a very peculiar widget  ( https://developer.gnome.org/gtk3/stable/gtk3-High-level-Printing-API.html) it seems that we can not returns a widget from the demo. So I just disable the font change in the demo selector (`TreeView` on the left of the UI) when the returned value does not have a `signal_connect` method. 