### PR TITLE
Update to new api of GLib::Bytes

### DIFF
--- a/gtk3/lib/gtk3/text-buffer.rb
+++ b/gtk3/lib/gtk3/text-buffer.rb
@@ -135,7 +135,7 @@ module Gtk
         when TextChildAnchor
           insert_text_child_anchor_raw(iter, target)
         else
-          insert_raw(iter, target, target.bytesize)
+          insert_raw(iter, target, target.to_s.length)
         end
       end
 


### PR DESCRIPTION
I found this bug when I ran the markup.rb demo from Gtk3 gtk-demo : 

    ./main.rb -r markup