### PR TITLE
glib-enum-types.h sometimes generated order ramdomness

### DIFF
--- a/glib2/lib/glib-mkenums.rb
+++ b/glib2/lib/glib-mkenums.rb
@@ -158,7 +158,7 @@ GType #{@enum_name}_get_type (void);
       @target_filename = target_filename
       @include_files = include_files
       @targets = []
-      files.each do |path|
+      files.sort.each do |path|
         data = ""
         File.open(path) do |i|
           data = i.read


### PR DESCRIPTION
According to [ruby-gnome2 diffoscope](https://tests.reproducible-builds.org/debian/dbd/unstable/armhf/ruby-gnome2_3.1.0-1.diffoscope.html#ruby-gnome--dev_-.-.---_armhf.deb-data.tar.xz-data.tar-.-usr-lib-arm-linux-gnueabihf-ruby-vendor_ruby--.-.--glib-enum-types.h), glib-enum-types.h sometimes generated order ramdomness.

* [glib2/ext/glib2/extconf.rb](https://github.com/ruby-gnome2/ruby-gnome2/blob/3.1.6/glib2/ext/glib2/extconf.rb#L68-L77)
    * [glib2/lib/mkmf-gnome2.rb#glib_mkenums](https://github.com/ruby-gnome2/ruby-gnome2/blob/3.1.6/glib2/lib/mkmf-gnome2.rb#L426)
        * [glib2/lib/glib-mkenums.rb#GLib::MkEnums.create](https://github.com/ruby-gnome2/ruby-gnome2/blob/3.1.6/glib2/lib/glib-mkenums.rb#L139-L140)
        * [glib2/lib/glib-mkenums.rb#GLib::MkEnums.new](https://github.com/ruby-gnome2/ruby-gnome2/blob/3.1.6/glib2/lib/glib-mkenums.rb#L161)

I think it is caused by Dir.glob that does not guarantee the order of the files.