### PR TITLE
Poppler test annotation

### DIFF
--- a/poppler/lib/poppler/document.rb
+++ b/poppler/lib/poppler/document.rb
@@ -16,6 +16,11 @@
 
 module Poppler
   class Document
+    # TODO :
+    # new_from_file
+    # new_from_data
+    # new_from_gstream
+    # new_from_gfile (should we ?)
 
     alias_method :[], :get_page
   end

--- a/poppler/lib/poppler/document.rb
+++ b/poppler/lib/poppler/document.rb
@@ -15,19 +15,8 @@
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 
 module Poppler
-  class Loader < GObjectIntrospection::Loader
-    private
-    def pre_load(repository, namespace)
-    end
+  class Document
 
-    def post_load(repository, namespace)
-      require_libraries
-    end
-
-    def require_libraries
-      require "poppler/version"
-      require "poppler/annot-callout-line"
-      require "poppler/document"
-    end
+    alias_method :[], :get_page
   end
 end

--- a/poppler/test/poppler-test-utils.rb
+++ b/poppler/test/poppler-test-utils.rb
@@ -1,4 +1,4 @@
-require 'open-uri'
+require 'uri'
 require 'fileutils'
 
 module PopplerTestUtils
@@ -26,7 +26,7 @@ module PopplerTestUtils
     File.open(file, "wb") do |output|
       output.print(pdf)
     end
-    file
+    URI.join('file:///', file.path)
   end
 
   def image_pdf

--- a/poppler/test/poppler-test-utils.rb
+++ b/poppler/test/poppler-test-utils.rb
@@ -21,12 +21,13 @@ module PopplerTestUtils
 
   def form_pdf
     file = File.join(fixtures_dir, "form.pdf")
-    return file if File.exist?(file)
+    uri = URI.join("file:///", file)
+    return uri.to_s if File.exist?(file)
     pdf = open("https://www.irs.gov/pub/irs-pdf/fw9.pdf").read
     File.open(file, "wb") do |output|
       output.print(pdf)
     end
-    URI.join('file:///', file.path)
+    uri.to_s
   end
 
   def image_pdf

--- a/poppler/test/test-annotation.rb
+++ b/poppler/test/test-annotation.rb
@@ -1,7 +1,7 @@
 class TestAnnotation < Test::Unit::TestCase
   def test_type
     only_poppler_version(0, 7, 2)
-    assert_kind_of(Poppler::AnnotationType, annotation.type)
+    assert_kind_of(Poppler::AnnotType, annotation)
   end
 
   def test_contents
@@ -21,7 +21,7 @@ class TestAnnotation < Test::Unit::TestCase
 
   def test_flags
     only_poppler_version(0, 7, 2)
-    assert_kind_of(Poppler::AnnotationFlag, annotation.flags)
+    assert_kind_of(Poppler::AnnotFlag, annotation.flags)
   end
 
   def test_color
@@ -32,28 +32,28 @@ class TestAnnotation < Test::Unit::TestCase
   def test_markup
     only_poppler_version(0, 7, 2)
     # We don't have a PDF that has annotation markup...
-    assert_method_defined(Poppler::AnnotationMarkup, :label)
-    assert_method_defined(Poppler::AnnotationMarkup, :popup_is_open?)
-    assert_method_defined(Poppler::AnnotationMarkup, :opacity)
-    assert_method_defined(Poppler::AnnotationMarkup, :date)
-    assert_method_defined(Poppler::AnnotationMarkup, :subject)
-    assert_method_defined(Poppler::AnnotationMarkup, :reply_to)
-    assert_method_defined(Poppler::AnnotationMarkup, :external_data)
+    assert_method_defined(Poppler::AnnotMarkup, :label)
+    assert_method_defined(Poppler::AnnotMarkup, :popup_is_open?)
+    assert_method_defined(Poppler::AnnotMarkup, :opacity)
+    assert_method_defined(Poppler::AnnotMarkup, :date)
+    assert_method_defined(Poppler::AnnotMarkup, :subject)
+    assert_method_defined(Poppler::AnnotMarkup, :reply_to)
+    assert_method_defined(Poppler::AnnotMarkup, :external_data)
   end
 
   def test_text
     only_poppler_version(0, 7, 2)
     # We don't have a PDF that has annotation text...
-    assert_method_defined(Poppler::AnnotationText, :open?)
-    assert_method_defined(Poppler::AnnotationText, :icon)
-    assert_method_defined(Poppler::AnnotationText, :state)
+    assert_method_defined(Poppler::AnnotText, :open?)
+    assert_method_defined(Poppler::AnnotText, :icon)
+    assert_method_defined(Poppler::AnnotText, :state)
   end
 
   def test_free_text
     only_poppler_version(0, 7, 2)
     # We don't have a PDF that has annotation free text...
-    assert_method_defined(Poppler::AnnotationFreeText, :quadding)
-    assert_method_defined(Poppler::AnnotationFreeText, :callout_line)
+    assert_method_defined(Poppler::AnnotFreeText, :quadding)
+    assert_method_defined(Poppler::AnnotFreeText, :callout_line)
   end
 
   def test_callout_line
@@ -75,7 +75,7 @@ class TestAnnotation < Test::Unit::TestCase
   def annotation
     document = Poppler::Document.new(form_pdf)
     page = document[0]
-    page.annotation_mapping[0].annotation
+    page.annot_mapping[0].annot
   end
 
   def assert_method_defined(object, method)


### PR DESCRIPTION
test-annotation is still failing with : 

```
Failure:
  <#<Poppler::Annot:0x1436448 ptr=0xd15340>> was expected to be kind_of?
  <Poppler::AnnotType> but was
  <Poppler::Annot>.
test_type(TestAnnotation)
/home/cedlemo/Projets/Ruby/ruby-gnome2/poppler/test/test-annotation.rb:4:in `test_type'
     1: class TestAnnotation < Test::Unit::TestCase
     2:   def test_type
     3:     only_poppler_version(0, 7, 2)
  => 4:     assert_kind_of(Poppler::AnnotType, annotation)
     5:   end
     6: 
     7:   def test_contents
```