### PR TITLE
add generate gemspec task

### DIFF
--- a/glib2/lib/gnome2/rake/package-task.rb
+++ b/glib2/lib/gnome2/rake/package-task.rb
@@ -286,6 +286,13 @@ module GNOME2
       def define_package_tasks
         Gem::PackageTask.new(@spec) do |pkg|
         end
+        desc "Write #{@spec.name}.gemspec"
+        task :gemspec do
+          File.open("#{@spec.name}.gemspec", 'w') do |f|
+            f.write(@spec.to_ruby)
+          end
+          puts "#{@spec.name}.gemspec created"
+        end
       end
 
       class DependencyConfiguration


### PR DESCRIPTION
I am working on Debian BTS: [ruby-gnome2: Please provide rubygem meta-information](https://bugs.debian.org/757464).
Antonio Terceiro <terceiro@debian.org> created this patch.
see:
https://lists.debian.org/debian-ruby/2017/07/msg00029.html
https://lists.debian.org/debian-ruby/2017/07/msg00030.html