### PR TITLE
Vte3 regex

### DIFF
--- a/vte3/lib/vte3/loader.rb
+++ b/vte3/lib/vte3/loader.rb
@@ -44,6 +44,7 @@ module Vte
       require "vte3/pty"
       require "vte3/terminal"
       require "vte3/version"
+      require "vte3/regex" # need to be after version because I use Version.or_later? in it
 
       require "vte3/deprecated"
     end

--- a/vte3/lib/vte3/regex.rb
+++ b/vte3/lib/vte3/regex.rb
@@ -1,4 +1,4 @@
-# Copyright (C) 2015  Ruby-GNOME2 Project Team
+# Copyright (C) 2017  Ruby-GNOME2 Project Team
 #
 # This library is free software; you can redistribute it and/or
 # modify it under the terms of the GNU Lesser General Public

--- a/vte3/lib/vte3/regex.rb
+++ b/vte3/lib/vte3/regex.rb
@@ -1,0 +1,52 @@
+# Copyright (C) 2015  Ruby-GNOME2 Project Team
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+
+module Vte
+  if Version.or_later?(0, 46)
+    class Regex
+      alias_method :initialize_raw, :initialize
+      def initialize(pattern, compile_flags, options)
+        flags = parse_compile_flags(compile_flags)
+        if options[:for_match]
+          initialize_new_for_match(pattern, pattern.length, flags)
+        elsif options[:for_search]
+          initialize_new_for_search(pattern, pattern.length, flags)
+        else
+          raise(ArgumentError,
+                "must specify usage :for_match or :for_search : #{options.inspect}")
+        end
+      end
+
+      private
+
+      def parse_compile_flags(compile_flags)
+        return compile_flags if compile_flags.class == Integer
+
+        flags = 0
+        return flags unless compile_flags.class == Array
+
+        compile_flags.each do |flag|
+          begin
+            flags = flags | GLib::RegexCompileFlags.const_get(flag.to_s.upcase).to_i
+          rescue
+          end
+        end
+
+        flags
+      end
+    end
+  end
+end

--- a/vte3/test/test-terminal-regex.rb
+++ b/vte3/test/test-terminal-regex.rb
@@ -1,0 +1,37 @@
+# Copyright (C) 2017 Ruby-GNOME2 Project Team
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+
+class TestTerminalRegex < Test::Unit::TestCase
+  include VteTestUtils
+
+  def setup
+    @terminal = Vte::Terminal.new
+  end
+
+  if Vte::Version.or_later?(0, 46)
+    def test_regex_for_match
+      regex = Vte::Regex.new("test", GLib::RegexCompileFlags::OPTIMIZE, :for_match => true)
+      assert_instance_of(Vte::Regex, regex)
+    end
+
+    def test_regex_for_match_multiple_flags
+      flags = [:optimize,
+               :multiline]
+      regex = Vte::Regex.new("test", flags, :for_match => true)
+      assert_instance_of(Vte::Regex, regex)
+    end
+  end
+end


### PR DESCRIPTION
@kou,

These Pull Request add support for `Vte::Regex`, the usage of `Glib::Regex` with `Vte::Terminal` is still working (with v = 0.48.3 at least) but is deprecated. (https://developer.gnome.org/vte/0.48/VteRegex.html).

I am sorry for the bad tests, I know that you consider that `assert_instance_of` are useless tests but I did not find anything else to test.