### PR TITLE
Use pkgconfig(foo) virtual provides for Red Hat based dependency

### DIFF
--- a/atk/dependency-check/Rakefile
+++ b/atk/dependency-check/Rakefile
@@ -32,7 +32,7 @@ namespace :dependency do
     unless PKGConfig.check_version?("atk")
       unless NativePackageInstaller.install(:altlinux => "libatk-devel",
                                             :debian => "libatk1.0-dev",
-                                            :redhat => "atk-devel",
+                                            :redhat => "pkgconfig(atk)",
                                             :arch => "atk",
                                             :homebrew => "atk",
                                             :macports => "atk",

--- a/clutter-gstreamer/dependency-check/Rakefile
+++ b/clutter-gstreamer/dependency-check/Rakefile
@@ -31,6 +31,7 @@ namespace :dependency do
   task :check do
     unless PKGConfig.check_version?("clutter-gst-3.0")
       unless NativePackageInstaller.install(:debian => "libclutter-gst-3.0-dev",
+                                            :redhat => "pkgconfig(clutter-gst-3.0)",
                                             :homebrew => "clutter-gst",
                                             :msys2 => "clutter-gst")
         exit(false)

--- a/clutter-gtk/dependency-check/Rakefile
+++ b/clutter-gtk/dependency-check/Rakefile
@@ -31,6 +31,7 @@ namespace :dependency do
   task :check do
     unless PKGConfig.check_version?("clutter-gtk-1.0")
       unless NativePackageInstaller.install(:debian => "libclutter-gtk-1.0-dev",
+                                            :redhat => "pkgconfig(clutter-gtk-1.0)",
                                             :homebrew => "clutter-gtk",
                                             :msys2 => "clutter-gtk")
         exit(false)

--- a/clutter/dependency-check/Rakefile
+++ b/clutter/dependency-check/Rakefile
@@ -31,6 +31,7 @@ namespace :dependency do
   task :check do
     unless PKGConfig.check_version?("clutter-1.0")
       unless NativePackageInstaller.install(:debian => "libclutter-1.0-dev",
+                                            :redhat => "pkgconfig(clutter-1.0)",
                                             :homebrew => "clutter",
                                             :msys2 => "clutter")
         exit(false)

--- a/gdk3/dependency-check/Rakefile
+++ b/gdk3/dependency-check/Rakefile
@@ -32,7 +32,7 @@ namespace :dependency do
     unless PKGConfig.check_version?("gdk-3.0")
       unless NativePackageInstaller.install(:altlinux => "libgtk+3-devel",
                                             :debian => "libgtk-3-dev",
-                                            :redhat => "gtk3-devel",
+                                            :redhat => "pkgconfig(gdk-3.0)",
                                             :homebrew => "gtk+3",
                                             :macports => "gtk3",
                                             :msys2 => "gtk3")

--- a/gdk_pixbuf2/dependency-check/Rakefile
+++ b/gdk_pixbuf2/dependency-check/Rakefile
@@ -32,8 +32,7 @@ namespace :dependency do
     unless PKGConfig.check_version?("gdk-pixbuf-2.0")
       unless NativePackageInstaller.install(:altlinux => "gdk-pixbuf-devel",
                                             :debian => "libgdk-pixbuf2.0-dev",
-                                            :redhat => "gtk2-devel",
-                                            :fedora => "gdk-pixbuf2-devel",
+                                            :redhat => "pkgconfig(gdk-pixbuf-2.0)",
                                             :arch => "gdk-pixbuf2",
                                             :homebrew => "gdk-pixbuf",
                                             :macports => "gdk-pixbuf2",

--- a/goffice/dependency-check/Rakefile
+++ b/goffice/dependency-check/Rakefile
@@ -48,13 +48,14 @@ namespace :dependency do
     unless PKGConfig.check_version?("libgoffice-0.10")
       goffice010_spec = {
         :debian => "libgoffice-0.10-dev",
+        :redhat => "pkgconfig(libgoffice-0.10)",
         :homebrew => "goffice",
       }
       unless NativePackageInstaller.install(goffice010_spec)
         unless PKGConfig.check_version?("libgoffice-0.8")
           goffice08_spec = {
             :debian => "libgoffice-0.8-dev",
-            :redhat => "goffice08-devel",
+            :redhat => "pkgconfig(libgoffice-0.8)",
             :homebrew => "goffice",
           }
           unless NativePackageInstaller.install(goffice08_spec)

--- a/gsf/dependency-check/Rakefile
+++ b/gsf/dependency-check/Rakefile
@@ -31,6 +31,7 @@ namespace :dependency do
   task :check do
     unless PKGConfig.check_version?("libgsf-1")
       unless NativePackageInstaller.install(:debian => "libgsf-1-dev",
+                                            :redhat => "pkgconfig(libgsf-1)",
                                             :homebrew => "libgsf",
                                             :msys2 => "libgsf")
         exit(false)

--- a/gtksourceview3/dependency-check/Rakefile
+++ b/gtksourceview3/dependency-check/Rakefile
@@ -32,7 +32,7 @@ namespace :dependency do
     unless PKGConfig.check_version?("gtksourceview-3.0")
       unless NativePackageInstaller.install(:altlinux => "libgtksourceview3-devel",
                                             :debian => "libgtksourceview-3.0-dev",
-                                            :redhat => "gtksourceview3-devel",
+                                            :redhat => "pkgconfig(gtksourceview-3.0)",
                                             :homebrew => "gtksourceview3",
                                             :macports => "gtksourceview3",
                                             :msys2 => "gtksourceview3")

--- a/poppler/dependency-check/Rakefile
+++ b/poppler/dependency-check/Rakefile
@@ -32,7 +32,7 @@ namespace :dependency do
     unless PKGConfig.check_version?("poppler", 0, 12, 0)
       unless NativePackageInstaller.install(:alt_linux => "libpoppler-glib-devel",
                                             :debian => "libpoppler-glib-dev",
-                                            :redhat => "poppler-glib-devel",
+                                            :redhat => "pkgconfig(poppler-glib)",
                                             :arch_linux => "poppler",
                                             :homebrew => "poppler",
                                             :macports => "poppler",

--- a/rsvg2/dependency-check/Rakefile
+++ b/rsvg2/dependency-check/Rakefile
@@ -32,7 +32,7 @@ namespace :dependency do
     unless PKGConfig.check_version?("librsvg-2.0")
       unless NativePackageInstaller.install(:altlinux => "librsvg-devel",
                                             :debian => "librsvg2-dev",
-                                            :redhat => "librsvg2-devel",
+                                            :redhat => "pkgconfig(librsvg-2.0)",
                                             :arch => "librsvg",
                                             :homebrew => "librsvg",
                                             :macports => "librsvg",

--- a/vte3/dependency-check/Rakefile
+++ b/vte3/dependency-check/Rakefile
@@ -33,7 +33,7 @@ namespace :dependency do
     unless PKGConfig.check_version?("vte-2.91")
       unless NativePackageInstaller.install(:altlinux => "libvte3-devel",
                                             :debian => "libvte-2.91-dev",
-                                            :redhat => "vte3-devel",
+                                            :redhat => "pkgconfig(vte-2.91)",
                                             :homebrew => "vte3")
         exit(false)
       end

--- a/webkit-gtk/dependency-check/Rakefile
+++ b/webkit-gtk/dependency-check/Rakefile
@@ -31,6 +31,7 @@ namespace :dependency do
   task :check do
     unless PKGConfig.check_version?("webkitgtk-3.0")
       unless NativePackageInstaller.install(:debian => "libwebkitgtk-3.0-dev",
+                                            :redhat => "pkgconfig(webkitgtk-3.0)",
                                             :msys2 => "webkitgtk3")
         exit(false)
       end

--- a/webkit2-gtk/dependency-check/Rakefile
+++ b/webkit2-gtk/dependency-check/Rakefile
@@ -31,6 +31,7 @@ namespace :dependency do
   task :check do
     unless PKGConfig.check_version?("webkit2gtk-4.0")
       unless NativePackageInstaller.install(:debian => "libwebkit2gtk-4.0-dev",
+                                            :redhat => "pkgconfig(webkit2gtk-4.0)",
                                             :homebrew => "webkitgtk")
         exit(false)
       end


### PR DESCRIPTION
As I wrote on https://github.com/ruby-gnome2/native-package-installer/issues/8 , Red Hat / Fedora package provides pkgconfig(foo) is such package contains foo.pc pkgconfig file. 

So instead of using package (rpm) name directory, using such virtual provides is preferred.

Note: I did not modify gnumeric/dependency-check/Rakefile this time, because this file does not contain ``unless PKGConfig.check_version?("foo")`` (yet?)