### PR TITLE
Gtk4 first commit

### DIFF
--- a/gtk4/COPYING.LIB
+++ b/gtk4/COPYING.LIB
@@ -1,0 +1,502 @@
+                  GNU LESSER GENERAL PUBLIC LICENSE
+                       Version 2.1, February 1999
+
+ Copyright (C) 1991, 1999 Free Software Foundation, Inc.
+ 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ Everyone is permitted to copy and distribute verbatim copies
+ of this license document, but changing it is not allowed.
+
+[This is the first released version of the Lesser GPL.  It also counts
+ as the successor of the GNU Library Public License, version 2, hence
+ the version number 2.1.]
+
+                            Preamble
+
+  The licenses for most software are designed to take away your
+freedom to share and change it.  By contrast, the GNU General Public
+Licenses are intended to guarantee your freedom to share and change
+free software--to make sure the software is free for all its users.
+
+  This license, the Lesser General Public License, applies to some
+specially designated software packages--typically libraries--of the
+Free Software Foundation and other authors who decide to use it.  You
+can use it too, but we suggest you first think carefully about whether
+this license or the ordinary General Public License is the better
+strategy to use in any particular case, based on the explanations below.
+
+  When we speak of free software, we are referring to freedom of use,
+not price.  Our General Public Licenses are designed to make sure that
+you have the freedom to distribute copies of free software (and charge
+for this service if you wish); that you receive source code or can get
+it if you want it; that you can change the software and use pieces of
+it in new free programs; and that you are informed that you can do
+these things.
+
+  To protect your rights, we need to make restrictions that forbid
+distributors to deny you these rights or to ask you to surrender these
+rights.  These restrictions translate to certain responsibilities for
+you if you distribute copies of the library or if you modify it.
+
+  For example, if you distribute copies of the library, whether gratis
+or for a fee, you must give the recipients all the rights that we gave
+you.  You must make sure that they, too, receive or can get the source
+code.  If you link other code with the library, you must provide
+complete object files to the recipients, so that they can relink them
+with the library after making changes to the library and recompiling
+it.  And you must show them these terms so they know their rights.
+
+  We protect your rights with a two-step method: (1) we copyright the
+library, and (2) we offer you this license, which gives you legal
+permission to copy, distribute and/or modify the library.
+
+  To protect each distributor, we want to make it very clear that
+there is no warranty for the free library.  Also, if the library is
+modified by someone else and passed on, the recipients should know
+that what they have is not the original version, so that the original
+author's reputation will not be affected by problems that might be
+introduced by others.
+
+  Finally, software patents pose a constant threat to the existence of
+any free program.  We wish to make sure that a company cannot
+effectively restrict the users of a free program by obtaining a
+restrictive license from a patent holder.  Therefore, we insist that
+any patent license obtained for a version of the library must be
+consistent with the full freedom of use specified in this license.
+
+  Most GNU software, including some libraries, is covered by the
+ordinary GNU General Public License.  This license, the GNU Lesser
+General Public License, applies to certain designated libraries, and
+is quite different from the ordinary General Public License.  We use
+this license for certain libraries in order to permit linking those
+libraries into non-free programs.
+
+  When a program is linked with a library, whether statically or using
+a shared library, the combination of the two is legally speaking a
+combined work, a derivative of the original library.  The ordinary
+General Public License therefore permits such linking only if the
+entire combination fits its criteria of freedom.  The Lesser General
+Public License permits more lax criteria for linking other code with
+the library.
+
+  We call this license the "Lesser" General Public License because it
+does Less to protect the user's freedom than the ordinary General
+Public License.  It also provides other free software developers Less
+of an advantage over competing non-free programs.  These disadvantages
+are the reason we use the ordinary General Public License for many
+libraries.  However, the Lesser license provides advantages in certain
+special circumstances.
+
+  For example, on rare occasions, there may be a special need to
+encourage the widest possible use of a certain library, so that it becomes
+a de-facto standard.  To achieve this, non-free programs must be
+allowed to use the library.  A more frequent case is that a free
+library does the same job as widely used non-free libraries.  In this
+case, there is little to gain by limiting the free library to free
+software only, so we use the Lesser General Public License.
+
+  In other cases, permission to use a particular library in non-free
+programs enables a greater number of people to use a large body of
+free software.  For example, permission to use the GNU C Library in
+non-free programs enables many more people to use the whole GNU
+operating system, as well as its variant, the GNU/Linux operating
+system.
+
+  Although the Lesser General Public License is Less protective of the
+users' freedom, it does ensure that the user of a program that is
+linked with the Library has the freedom and the wherewithal to run
+that program using a modified version of the Library.
+
+  The precise terms and conditions for copying, distribution and
+modification follow.  Pay close attention to the difference between a
+"work based on the library" and a "work that uses the library".  The
+former contains code derived from the library, whereas the latter must
+be combined with the library in order to run.
+
+                  GNU LESSER GENERAL PUBLIC LICENSE
+   TERMS AND CONDITIONS FOR COPYING, DISTRIBUTION AND MODIFICATION
+
+  0. This License Agreement applies to any software library or other
+program which contains a notice placed by the copyright holder or
+other authorized party saying it may be distributed under the terms of
+this Lesser General Public License (also called "this License").
+Each licensee is addressed as "you".
+
+  A "library" means a collection of software functions and/or data
+prepared so as to be conveniently linked with application programs
+(which use some of those functions and data) to form executables.
+
+  The "Library", below, refers to any such software library or work
+which has been distributed under these terms.  A "work based on the
+Library" means either the Library or any derivative work under
+copyright law: that is to say, a work containing the Library or a
+portion of it, either verbatim or with modifications and/or translated
+straightforwardly into another language.  (Hereinafter, translation is
+included without limitation in the term "modification".)
+
+  "Source code" for a work means the preferred form of the work for
+making modifications to it.  For a library, complete source code means
+all the source code for all modules it contains, plus any associated
+interface definition files, plus the scripts used to control compilation
+and installation of the library.
+
+  Activities other than copying, distribution and modification are not
+covered by this License; they are outside its scope.  The act of
+running a program using the Library is not restricted, and output from
+such a program is covered only if its contents constitute a work based
+on the Library (independent of the use of the Library in a tool for
+writing it).  Whether that is true depends on what the Library does
+and what the program that uses the Library does.
+
+  1. You may copy and distribute verbatim copies of the Library's
+complete source code as you receive it, in any medium, provided that
+you conspicuously and appropriately publish on each copy an
+appropriate copyright notice and disclaimer of warranty; keep intact
+all the notices that refer to this License and to the absence of any
+warranty; and distribute a copy of this License along with the
+Library.
+
+  You may charge a fee for the physical act of transferring a copy,
+and you may at your option offer warranty protection in exchange for a
+fee.
+
+  2. You may modify your copy or copies of the Library or any portion
+of it, thus forming a work based on the Library, and copy and
+distribute such modifications or work under the terms of Section 1
+above, provided that you also meet all of these conditions:
+
+    a) The modified work must itself be a software library.
+
+    b) You must cause the files modified to carry prominent notices
+    stating that you changed the files and the date of any change.
+
+    c) You must cause the whole of the work to be licensed at no
+    charge to all third parties under the terms of this License.
+
+    d) If a facility in the modified Library refers to a function or a
+    table of data to be supplied by an application program that uses
+    the facility, other than as an argument passed when the facility
+    is invoked, then you must make a good faith effort to ensure that,
+    in the event an application does not supply such function or
+    table, the facility still operates, and performs whatever part of
+    its purpose remains meaningful.
+
+    (For example, a function in a library to compute square roots has
+    a purpose that is entirely well-defined independent of the
+    application.  Therefore, Subsection 2d requires that any
+    application-supplied function or table used by this function must
+    be optional: if the application does not supply it, the square
+    root function must still compute square roots.)
+
+These requirements apply to the modified work as a whole.  If
+identifiable sections of that work are not derived from the Library,
+and can be reasonably considered independent and separate works in
+themselves, then this License, and its terms, do not apply to those
+sections when you distribute them as separate works.  But when you
+distribute the same sections as part of a whole which is a work based
+on the Library, the distribution of the whole must be on the terms of
+this License, whose permissions for other licensees extend to the
+entire whole, and thus to each and every part regardless of who wrote
+it.
+
+Thus, it is not the intent of this section to claim rights or contest
+your rights to work written entirely by you; rather, the intent is to
+exercise the right to control the distribution of derivative or
+collective works based on the Library.
+
+In addition, mere aggregation of another work not based on the Library
+with the Library (or with a work based on the Library) on a volume of
+a storage or distribution medium does not bring the other work under
+the scope of this License.
+
+  3. You may opt to apply the terms of the ordinary GNU General Public
+License instead of this License to a given copy of the Library.  To do
+this, you must alter all the notices that refer to this License, so
+that they refer to the ordinary GNU General Public License, version 2,
+instead of to this License.  (If a newer version than version 2 of the
+ordinary GNU General Public License has appeared, then you can specify
+that version instead if you wish.)  Do not make any other change in
+these notices.
+
+  Once this change is made in a given copy, it is irreversible for
+that copy, so the ordinary GNU General Public License applies to all
+subsequent copies and derivative works made from that copy.
+
+  This option is useful when you wish to copy part of the code of
+the Library into a program that is not a library.
+
+  4. You may copy and distribute the Library (or a portion or
+derivative of it, under Section 2) in object code or executable form
+under the terms of Sections 1 and 2 above provided that you accompany
+it with the complete corresponding machine-readable source code, which
+must be distributed under the terms of Sections 1 and 2 above on a
+medium customarily used for software interchange.
+
+  If distribution of object code is made by offering access to copy
+from a designated place, then offering equivalent access to copy the
+source code from the same place satisfies the requirement to
+distribute the source code, even though third parties are not
+compelled to copy the source along with the object code.
+
+  5. A program that contains no derivative of any portion of the
+Library, but is designed to work with the Library by being compiled or
+linked with it, is called a "work that uses the Library".  Such a
+work, in isolation, is not a derivative work of the Library, and
+therefore falls outside the scope of this License.
+
+  However, linking a "work that uses the Library" with the Library
+creates an executable that is a derivative of the Library (because it
+contains portions of the Library), rather than a "work that uses the
+library".  The executable is therefore covered by this License.
+Section 6 states terms for distribution of such executables.
+
+  When a "work that uses the Library" uses material from a header file
+that is part of the Library, the object code for the work may be a
+derivative work of the Library even though the source code is not.
+Whether this is true is especially significant if the work can be
+linked without the Library, or if the work is itself a library.  The
+threshold for this to be true is not precisely defined by law.
+
+  If such an object file uses only numerical parameters, data
+structure layouts and accessors, and small macros and small inline
+functions (ten lines or less in length), then the use of the object
+file is unrestricted, regardless of whether it is legally a derivative
+work.  (Executables containing this object code plus portions of the
+Library will still fall under Section 6.)
+
+  Otherwise, if the work is a derivative of the Library, you may
+distribute the object code for the work under the terms of Section 6.
+Any executables containing that work also fall under Section 6,
+whether or not they are linked directly with the Library itself.
+
+  6. As an exception to the Sections above, you may also combine or
+link a "work that uses the Library" with the Library to produce a
+work containing portions of the Library, and distribute that work
+under terms of your choice, provided that the terms permit
+modification of the work for the customer's own use and reverse
+engineering for debugging such modifications.
+
+  You must give prominent notice with each copy of the work that the
+Library is used in it and that the Library and its use are covered by
+this License.  You must supply a copy of this License.  If the work
+during execution displays copyright notices, you must include the
+copyright notice for the Library among them, as well as a reference
+directing the user to the copy of this License.  Also, you must do one
+of these things:
+
+    a) Accompany the work with the complete corresponding
+    machine-readable source code for the Library including whatever
+    changes were used in the work (which must be distributed under
+    Sections 1 and 2 above); and, if the work is an executable linked
+    with the Library, with the complete machine-readable "work that
+    uses the Library", as object code and/or source code, so that the
+    user can modify the Library and then relink to produce a modified
+    executable containing the modified Library.  (It is understood
+    that the user who changes the contents of definitions files in the
+    Library will not necessarily be able to recompile the application
+    to use the modified definitions.)
+
+    b) Use a suitable shared library mechanism for linking with the
+    Library.  A suitable mechanism is one that (1) uses at run time a
+    copy of the library already present on the user's computer system,
+    rather than copying library functions into the executable, and (2)
+    will operate properly with a modified version of the library, if
+    the user installs one, as long as the modified version is
+    interface-compatible with the version that the work was made with.
+
+    c) Accompany the work with a written offer, valid for at
+    least three years, to give the same user the materials
+    specified in Subsection 6a, above, for a charge no more
+    than the cost of performing this distribution.
+
+    d) If distribution of the work is made by offering access to copy
+    from a designated place, offer equivalent access to copy the above
+    specified materials from the same place.
+
+    e) Verify that the user has already received a copy of these
+    materials or that you have already sent this user a copy.
+
+  For an executable, the required form of the "work that uses the
+Library" must include any data and utility programs needed for
+reproducing the executable from it.  However, as a special exception,
+the materials to be distributed need not include anything that is
+normally distributed (in either source or binary form) with the major
+components (compiler, kernel, and so on) of the operating system on
+which the executable runs, unless that component itself accompanies
+the executable.
+
+  It may happen that this requirement contradicts the license
+restrictions of other proprietary libraries that do not normally
+accompany the operating system.  Such a contradiction means you cannot
+use both them and the Library together in an executable that you
+distribute.
+
+  7. You may place library facilities that are a work based on the
+Library side-by-side in a single library together with other library
+facilities not covered by this License, and distribute such a combined
+library, provided that the separate distribution of the work based on
+the Library and of the other library facilities is otherwise
+permitted, and provided that you do these two things:
+
+    a) Accompany the combined library with a copy of the same work
+    based on the Library, uncombined with any other library
+    facilities.  This must be distributed under the terms of the
+    Sections above.
+
+    b) Give prominent notice with the combined library of the fact
+    that part of it is a work based on the Library, and explaining
+    where to find the accompanying uncombined form of the same work.
+
+  8. You may not copy, modify, sublicense, link with, or distribute
+the Library except as expressly provided under this License.  Any
+attempt otherwise to copy, modify, sublicense, link with, or
+distribute the Library is void, and will automatically terminate your
+rights under this License.  However, parties who have received copies,
+or rights, from you under this License will not have their licenses
+terminated so long as such parties remain in full compliance.
+
+  9. You are not required to accept this License, since you have not
+signed it.  However, nothing else grants you permission to modify or
+distribute the Library or its derivative works.  These actions are
+prohibited by law if you do not accept this License.  Therefore, by
+modifying or distributing the Library (or any work based on the
+Library), you indicate your acceptance of this License to do so, and
+all its terms and conditions for copying, distributing or modifying
+the Library or works based on it.
+
+  10. Each time you redistribute the Library (or any work based on the
+Library), the recipient automatically receives a license from the
+original licensor to copy, distribute, link with or modify the Library
+subject to these terms and conditions.  You may not impose any further
+restrictions on the recipients' exercise of the rights granted herein.
+You are not responsible for enforcing compliance by third parties with
+this License.
+
+  11. If, as a consequence of a court judgment or allegation of patent
+infringement or for any other reason (not limited to patent issues),
+conditions are imposed on you (whether by court order, agreement or
+otherwise) that contradict the conditions of this License, they do not
+excuse you from the conditions of this License.  If you cannot
+distribute so as to satisfy simultaneously your obligations under this
+License and any other pertinent obligations, then as a consequence you
+may not distribute the Library at all.  For example, if a patent
+license would not permit royalty-free redistribution of the Library by
+all those who receive copies directly or indirectly through you, then
+the only way you could satisfy both it and this License would be to
+refrain entirely from distribution of the Library.
+
+If any portion of this section is held invalid or unenforceable under any
+particular circumstance, the balance of the section is intended to apply,
+and the section as a whole is intended to apply in other circumstances.
+
+It is not the purpose of this section to induce you to infringe any
+patents or other property right claims or to contest validity of any
+such claims; this section has the sole purpose of protecting the
+integrity of the free software distribution system which is
+implemented by public license practices.  Many people have made
+generous contributions to the wide range of software distributed
+through that system in reliance on consistent application of that
+system; it is up to the author/donor to decide if he or she is willing
+to distribute software through any other system and a licensee cannot
+impose that choice.
+
+This section is intended to make thoroughly clear what is believed to
+be a consequence of the rest of this License.
+
+  12. If the distribution and/or use of the Library is restricted in
+certain countries either by patents or by copyrighted interfaces, the
+original copyright holder who places the Library under this License may add
+an explicit geographical distribution limitation excluding those countries,
+so that distribution is permitted only in or among countries not thus
+excluded.  In such case, this License incorporates the limitation as if
+written in the body of this License.
+
+  13. The Free Software Foundation may publish revised and/or new
+versions of the Lesser General Public License from time to time.
+Such new versions will be similar in spirit to the present version,
+but may differ in detail to address new problems or concerns.
+
+Each version is given a distinguishing version number.  If the Library
+specifies a version number of this License which applies to it and
+"any later version", you have the option of following the terms and
+conditions either of that version or of any later version published by
+the Free Software Foundation.  If the Library does not specify a
+license version number, you may choose any version ever published by
+the Free Software Foundation.
+
+  14. If you wish to incorporate parts of the Library into other free
+programs whose distribution conditions are incompatible with these,
+write to the author to ask for permission.  For software which is
+copyrighted by the Free Software Foundation, write to the Free
+Software Foundation; we sometimes make exceptions for this.  Our
+decision will be guided by the two goals of preserving the free status
+of all derivatives of our free software and of promoting the sharing
+and reuse of software generally.
+
+                            NO WARRANTY
+
+  15. BECAUSE THE LIBRARY IS LICENSED FREE OF CHARGE, THERE IS NO
+WARRANTY FOR THE LIBRARY, TO THE EXTENT PERMITTED BY APPLICABLE LAW.
+EXCEPT WHEN OTHERWISE STATED IN WRITING THE COPYRIGHT HOLDERS AND/OR
+OTHER PARTIES PROVIDE THE LIBRARY "AS IS" WITHOUT WARRANTY OF ANY
+KIND, EITHER EXPRESSED OR IMPLIED, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+PURPOSE.  THE ENTIRE RISK AS TO THE QUALITY AND PERFORMANCE OF THE
+LIBRARY IS WITH YOU.  SHOULD THE LIBRARY PROVE DEFECTIVE, YOU ASSUME
+THE COST OF ALL NECESSARY SERVICING, REPAIR OR CORRECTION.
+
+  16. IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN
+WRITING WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MAY MODIFY
+AND/OR REDISTRIBUTE THE LIBRARY AS PERMITTED ABOVE, BE LIABLE TO YOU
+FOR DAMAGES, INCLUDING ANY GENERAL, SPECIAL, INCIDENTAL OR
+CONSEQUENTIAL DAMAGES ARISING OUT OF THE USE OR INABILITY TO USE THE
+LIBRARY (INCLUDING BUT NOT LIMITED TO LOSS OF DATA OR DATA BEING
+RENDERED INACCURATE OR LOSSES SUSTAINED BY YOU OR THIRD PARTIES OR A
+FAILURE OF THE LIBRARY TO OPERATE WITH ANY OTHER SOFTWARE), EVEN IF
+SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH
+DAMAGES.
+
+                     END OF TERMS AND CONDITIONS
+
+           How to Apply These Terms to Your New Libraries
+
+  If you develop a new library, and you want it to be of the greatest
+possible use to the public, we recommend making it free software that
+everyone can redistribute and change.  You can do so by permitting
+redistribution under these terms (or, alternatively, under the terms of the
+ordinary General Public License).
+
+  To apply these terms, attach the following notices to the library.  It is
+safest to attach them to the start of each source file to most effectively
+convey the exclusion of warranty; and each file should have at least the
+"copyright" line and a pointer to where the full notice is found.
+
+    <one line to give the library's name and a brief idea of what it does.>
+    Copyright (C) <year>  <name of author>
+
+    This library is free software; you can redistribute it and/or
+    modify it under the terms of the GNU Lesser General Public
+    License as published by the Free Software Foundation; either
+    version 2.1 of the License, or (at your option) any later version.
+
+    This library is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+    Lesser General Public License for more details.
+
+    You should have received a copy of the GNU Lesser General Public
+    License along with this library; if not, write to the Free Software
+    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+
+Also add information on how to contact you by electronic and paper mail.
+
+You should also get your employer (if you work as a programmer) or your
+school, if any, to sign a "copyright disclaimer" for the library, if
+necessary.  Here is a sample; alter the names:
+
+  Yoyodyne, Inc., hereby disclaims all copyright interest in the
+  library `Frob' (a library for tweaking knobs) written by James Random Hacker.
+
+  <signature of Ty Coon>, 1 April 1990
+  Ty Coon, President of Vice
+
+That's all there is to it!

--- a/gtk4/README.md
+++ b/gtk4/README.md
@@ -1,0 +1,32 @@
+# Ruby/GTK4
+
+Ruby/GTK4 is a Ruby binding of GTK+ 4.
+
+## Requirements
+
+* Ruby/GLib2, Ruby/ATK, Ruby/Pango, Ruby/GdkPixbuf2, Ruby/GIO2,
+  Ruby/GDK4, Ruby/GObjectIntrospection and Ruby/GTK4 in
+  [Ruby-GNOME2](http://ruby-gnome2.sourceforge.jp/)
+* [rcairo](https://github.com/rcairo/rcairo)
+* [GTK+](http://www.gtk.org/)
+
+## Install
+
+    gem install gtk4
+
+## Tutorials, examples:
+
+* gtk4/sample/misc: a lot of simple examples.
+* gtk4/sample/gtk-demo: the ruby version of `gtk-demo`.
+
+## License
+
+Copyright (c) 2002-2018 Ruby-GNOME2 Project Team
+
+This program is free software. You can distribute/modify this program
+under the terms of the GNU LESSER GENERAL PUBLIC LICENSE Version 2.1.
+
+## Project Websites
+
+* https://github.com/ruby-gnome2/ruby-gnome2
+* http://ruby-gnome2.sourceforge.jp/

--- a/gtk4/Rakefile
+++ b/gtk4/Rakefile
@@ -1,0 +1,21 @@
+# -*- ruby -*-
+
+$LOAD_PATH.unshift("./../glib2/lib")
+require 'gnome2/rake/package-task'
+
+package_task = GNOME2::Rake::PackageTask.new do |package|
+  package.summary = "Ruby/GTK4 is a Ruby binding of GTK+-4.x."
+  package.description = "Ruby/GTK4 is a Ruby binding of GTK+-4.x."
+  package.dependency.gem.runtime = [
+    "glib2",
+    "gio2",
+    "atk",
+    "pango",
+    "gdk_pixbuf2",
+    "gdk4",
+    "gobject-introspection",
+  ]
+  package.windows.packages = []
+  package.windows.dependencies = []
+end
+package_task.define

--- a/gtk4/lib/gtk4.rb
+++ b/gtk4/lib/gtk4.rb
@@ -1,0 +1,68 @@
+# Copyright (C) 2006-2018  Ruby-GNOME2 Project Team
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+
+require "gobject-introspection"
+require "atk"
+require "gdk4"
+require "gio2"
+
+if /cygwin|mingw|mswin/ === RUBY_PLATFORM
+  require "rsvg2"
+end
+
+require "gtk4/loader"
+
+module Gtk
+  LOG_DOMAIN = "Gtk"
+  GLib::Log.set_log_domain(LOG_DOMAIN)
+
+  class Error < StandardError
+  end
+
+  class InitError < Error
+  end
+
+  class << self
+    def const_missing(name)
+      init()
+      if const_defined?(name)
+        const_get(name)
+      else
+        super
+      end
+    end
+
+    def method_missing(name, *args, &block)
+      init()
+      if respond_to?(name)
+        __send__(name, *args, &block)
+      else
+        super
+      end
+    end
+
+    def init(*argv)
+      class << self
+        remove_method(:init)
+        remove_method(:const_missing)
+        remove_method(:method_missing)
+      end
+      Gdk.init if Gdk.respond_to?(:init)
+      loader = Loader.new(self, argv)
+      loader.load
+    end
+  end
+end

--- a/gtk4/lib/gtk4/about-dialog.rb
+++ b/gtk4/lib/gtk4/about-dialog.rb
@@ -1,0 +1,34 @@
+# Copyright (C) 2015  Ruby-GNOME2 Project Team
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+
+module Gtk
+  class AboutDialog
+    class << self
+      def show(parent=nil, attributes=nil)
+        dialog = new
+        (attributes || {}).each do |key, value|
+          dialog.send("#{key}=", value)
+        end
+        if parent
+          dialog.modal = true
+          dialog.transient_for = parent
+          dialog.destroy_with_parent = true
+        end
+        dialog.present
+      end
+    end
+  end
+end

--- a/gtk4/lib/gtk4/action-group.rb
+++ b/gtk4/lib/gtk4/action-group.rb
@@ -1,0 +1,131 @@
+# Copyright (C) 2015-2017  Ruby-GNOME2 Project Team
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+
+module Gtk
+  class ActionGroup
+    alias_method :add_action_raw, :add_action
+    def add_action(action, options={})
+      accelerator = options[:accelerator]
+
+      if accelerator
+        add_action_with_accel(action, accelerator)
+      else
+        add_action_raw(action)
+      end
+    end
+
+    def add_actions(actions)
+      actions.each do |config|
+        if config.is_a?(Array)
+          name        = config[0]
+          stock_id    = config[1]
+          label       = config[2]
+          accelerator = config[3]
+          tooltip     = config[4]
+          callback    = config[5]
+        else
+          name        = config[:name]
+          stock_id    = config[:stock_id]
+          label       = config[:label]
+          accelerator = config[:accelerator]
+          tooltip     = config[:tooltip]
+          callback    = config[:callback]
+        end
+
+        action = Action.new(name,
+                            :label    => translate_string(label),
+                            :tooltip  => translate_string(tooltip),
+                            :stock_id => stock_id)
+        action.signal_connect("activate") do
+          callback.call(self, action)
+        end
+        add_action(action, :accelerator => accelerator)
+      end
+    end
+
+    def add_toggle_actions(actions)
+      actions.each do |config|
+        if config.is_a?(Array)
+          name        = config[0]
+          stock_id    = config[1]
+          label       = config[2]
+          accelerator = config[3]
+          tooltip     = config[4]
+          callback    = config[5]
+          is_active   = config[6]
+        else
+          name        = config[:name]
+          stock_id    = config[:stock_id]
+          label       = config[:label]
+          accelerator = config[:accelerator]
+          tooltip     = config[:tooltip]
+          callback    = config[:callback]
+          is_active   = config[:is_active]
+        end
+
+        action = ToggleAction.new(name,
+                                  :label    => translate_string(label),
+                                  :tooltip  => translate_string(tooltip),
+                                  :stock_id => stock_id)
+        action.active = true if is_active
+        action.signal_connect("activate") do
+          callback.call(self, action)
+        end
+        add_action(action, :accelerator => accelerator)
+      end
+    end
+
+    def add_radio_actions(actions, default_value=nil)
+      actions.each_with_index do |config, i|
+        if config.is_a?(Array)
+          name        = config[0]
+          stock_id    = config[1]
+          label       = config[2]
+          accelerator = config[3]
+          tooltip     = config[4]
+          value       = config[5]
+        else
+          name        = config[:name]
+          stock_id    = config[:stock_id]
+          label       = config[:label]
+          accelerator = config[:accelerator]
+          tooltip     = config[:tooltip]
+          value       = config[:value]
+        end
+
+        action = RadioAction.new(name,
+                                 value,
+                                 :label    => translate_string(label),
+                                 :tooltip  => translate_string(tooltip),
+                                 :stock_id => stock_id)
+        action.active = true if value == default_value
+        if i.zero?
+          action.signal_connect("changed") do |connected_action, current_action|
+            yield(connected_action, current_action)
+          end
+        end
+        add_action(action, :accelerator => accelerator)
+      end
+    end
+
+    alias_method :translate_string_raw, :translate_string
+    def translate_string(string)
+      return nil if string.nil?
+
+      translate_string_raw(string)
+    end
+  end
+end

--- a/gtk4/lib/gtk4/action.rb
+++ b/gtk4/lib/gtk4/action.rb
@@ -1,0 +1,27 @@
+# Copyright (C) 2015  Ruby-GNOME2 Project Team
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+
+module Gtk
+  class Action
+    alias_method :initialize_raw, :initialize
+    def initialize(name, options={})
+      initialize_raw(name,
+                     options[:label],
+                     options[:tooltip],
+                     options[:stock_id])
+    end
+  end
+end

--- a/gtk4/lib/gtk4/binding-set.rb
+++ b/gtk4/lib/gtk4/binding-set.rb
@@ -1,0 +1,31 @@
+# Copyright (C) 2015  Ruby-GNOME2 Project Team
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+
+module Gtk
+  class BindingSet
+    def add_signal(description)
+      BindingEntry.add_signal_from_string(self, description)
+    end
+
+    def remove(key, modifiers)
+      BindingEntry.remove(self, key, modifiers)
+    end
+
+    def skip(key, modifiers)
+      BindingEntry.skip(self, key, modifiers)
+    end
+  end
+end

--- a/gtk4/lib/gtk4/border.rb
+++ b/gtk4/lib/gtk4/border.rb
@@ -1,0 +1,28 @@
+# Copyright (C) 2014  Ruby-GNOME2 Project Team
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+
+module Gtk
+  class Border
+    alias_method :initialize_raw, :initialize
+    def initialize(left, right, top, bottom)
+      initialize_raw
+      self.left = left
+      self.right = right
+      self.top = top
+      self.bottom = bottom
+    end
+  end
+end

--- a/gtk4/lib/gtk4/box.rb
+++ b/gtk4/lib/gtk4/box.rb
@@ -1,0 +1,62 @@
+# Copyright (C) 2014  Ruby-GNOME2 Project Team
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+
+module Gtk
+  class Box
+    alias_method :initialize_raw, :initialize
+    def initialize(orientation, spacing=0)
+      initialize_raw(orientation, spacing || 0)
+    end
+
+    alias_method :pack_start_raw, :pack_start
+    def pack_start(child, options={})
+      expand  = options[:expand]  || false
+      fill    = options[:fill]    || false
+      padding = options[:padding] || 0
+      pack_start_raw(child, expand, fill, padding)
+    end
+
+    alias_method :pack_end_raw, :pack_end
+    def pack_end(child, options={})
+      expand  = options[:expand]  || false
+      fill    = options[:fill]    || false
+      padding = options[:padding] || 0
+      pack_end_raw(child, expand, fill, padding)
+    end
+
+    alias_method :set_child_packing_raw, :set_child_packing
+    def set_child_packing(child, options={})
+      expand    = options[:expand]
+      fill      = options[:fill]
+      padding   = options[:padding]
+      pack_type = options[:pack_type]
+
+      old_expand, old_fill, old_padding, old_pack_type =
+        query_child_packing(child)
+
+      expand    = old_expand    if expand.nil?
+      fill      = old_fill      if fill.nil?
+      padding   = old_padding   if padding.nil?
+      pack_type = old_pack_type if pack_type.nil?
+
+      set_child_packing_raw(child,
+                            expand,
+                            fill,
+                            padding,
+                            pack_type)
+    end
+  end
+end

--- a/gtk4/lib/gtk4/builder.rb
+++ b/gtk4/lib/gtk4/builder.rb
@@ -1,0 +1,155 @@
+# Copyright (C) 2015-2016  Ruby-GNOME2 Project Team
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+
+module Gtk
+  class Builder
+    class << self
+      def connect_signal(builder,
+                         object,
+                         signal_name,
+                         handler_name,
+                         connect_object,
+                         flags,
+                         &block)
+        handler_name = normalize_handler_name(handler_name)
+        if connect_object
+          handler = connect_object.method(handler_name)
+        else
+          handler = block.call(handler_name)
+        end
+
+        unless handler
+          $stderr.puts("Undefined handler: #{handler_name}") if $DEBUG
+          return
+        end
+
+        if flags.is_a?(Integer)
+          flags = GLib::ConnectFlags.new(flags)
+        end
+
+        if flags.after?
+          signal_connect_method = :signal_connect_after
+        else
+          signal_connect_method = :signal_connect
+        end
+
+        if handler.arity.zero?
+          object.__send__(signal_connect_method, signal_name) do
+            handler.call
+          end
+        else
+          object.__send__(signal_connect_method, signal_name, &handler)
+        end
+      end
+
+      private
+      def normalize_handler_name(name)
+        name.gsub(/[-\s]+/, "_")
+      end
+    end
+
+    alias_method :initialize_raw, :initialize
+    def initialize(options={})
+      path      = options[:path] || options[:file]
+      resource  = options[:resource]
+      string    = options[:string]
+
+      if path
+        path = path.to_path if path.respond_to?(:to_path)
+        initialize_new_from_file(path)
+      elsif resource
+        initialize_new_from_resource(resource)
+      elsif string
+        initialize_new_from_string(string, string.bytesize)
+      else
+        initialize_raw
+      end
+    end
+
+    alias_method :[], :get_object
+
+    alias_method :add_from_string_raw, :add_from_string
+    def add_from_string(string)
+      add_from_string_raw(string, string.bytesize)
+    end
+
+    alias_method :add_objects_from_string_raw, :add_objects_from_string
+    def add_objects_from_string(string, object_ids)
+      add_objects_from_string_raw(string, string.bytesize, object_ids)
+    end
+
+    def add(target_or_options={})
+      if target_or_options.is_a?(Hash)
+        options = target_or_options
+      else
+        target = target_or_options
+        options = {}
+        if target.respond_to?(:to_path)
+          options[:path] = target.to_path
+        elsif target.start_with?("<") or target.start_with?(" ")
+          options[:string] = target
+        elsif File.exist?(target)
+          options[:path] = target
+        else
+          options[:resource] = target
+        end
+      end
+
+      string   = options[:string]
+      path     = options[:path] || options[:file]
+      resource = options[:resource]
+
+      object_ids = options[:object_ids]
+
+      if path
+        path = path.to_path if path.respond_to?(:to_path)
+        if object_ids
+          add_objects_from_file(path, object_ids)
+        else
+          add_from_file(path)
+        end
+      elsif resource
+        if object_ids
+          add_objects_from_resource(resource, object_ids)
+        else
+          add_from_resource(resource)
+        end
+      elsif string
+        if object_ids
+          add_objects_from_string(string, object_ids)
+        else
+          add_from_string(string)
+        end
+      else
+        message = ":path (:file), :resource or :string " +
+          "must be specified: #{options.inspect}"
+        raise InvalidArgument, message
+      end
+    end
+
+    def <<(target)
+      add(target)
+      self
+    end
+
+    alias_method :connect_signals_raw, :connect_signals
+    def connect_signals(&block)
+      connect_signals_raw do |*args|
+        self.class.connect_signal(*args, &block)
+      end
+    end
+  end
+end

--- a/gtk4/lib/gtk4/button.rb
+++ b/gtk4/lib/gtk4/button.rb
@@ -1,0 +1,53 @@
+# Copyright (C) 2014  Ruby-GNOME2 Project Team
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+
+module Gtk
+  class Button
+    alias_method :initialize_raw, :initialize
+    def initialize(options={})
+      label = options[:label]
+      use_underline = options[:use_underline]
+      if use_underline.nil?
+        mnemonic = options[:mnemonic]
+        if mnemonic
+          label = mnemonic
+          use_underline = true
+        end
+      end
+      stock = options[:stock_id]
+      icon_name = options[:icon_name]
+      icon_size = options[:icon_size] || :button
+
+      if label
+        if use_underline
+          initialize_new_with_mnemonic(label)
+        else
+          initialize_new_with_label(label)
+        end
+      elsif stock
+        initialize_new_from_stock(stock)
+      elsif icon_name
+        case icon_size
+        when Symbol, String
+          icon_size = IconSize.new(icon_size.to_s)
+        end
+        initialize_new_from_icon_name(icon_name, icon_size)
+      else
+        initialize_raw
+      end
+    end
+  end
+end

--- a/gtk4/lib/gtk4/calendar.rb
+++ b/gtk4/lib/gtk4/calendar.rb
@@ -1,0 +1,30 @@
+# Copyright (C) 2015  Ruby-GNOME2 Project Team
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+
+module Gtk
+  class Calendar
+    alias_method :select_month_raw, :select_month
+    def select_month(month, year)
+      select_month_raw(month - 1, year)
+    end
+
+    alias_method :date_raw, :date
+    def date
+      year, month, day = date_raw
+      [year, month + 1, day]
+    end
+  end
+end

--- a/gtk4/lib/gtk4/cell-layout.rb
+++ b/gtk4/lib/gtk4/cell-layout.rb
@@ -1,0 +1,31 @@
+# Copyright (C) 2015  Ruby-GNOME2 Project Team
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+
+module Gtk
+  module CellLayout
+    def set_attributes(cell, attributes)
+      attributes.each do |key, value|
+        add_attribute(cell, key, value)
+      end
+    end
+
+    alias_method :add_attribute_raw, :add_attribute
+    def add_attribute(cell, name, value)
+      name = name.to_s if name.is_a?(Symbol)
+      add_attribute_raw(cell, name, value)
+    end
+  end
+end

--- a/gtk4/lib/gtk4/check-menu-item.rb
+++ b/gtk4/lib/gtk4/check-menu-item.rb
@@ -1,0 +1,34 @@
+# Copyright (C) 2015  Ruby-GNOME2 Project Team
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+
+module Gtk
+  class CheckMenuItem
+    alias_method :initialize_raw, :initialize
+    def initialize(options={})
+      label = options[:label]
+
+      if label
+        if options[:use_underline]
+          initialize_new_with_mnemonic(label)
+        else
+          initialize_new_with_label(label)
+        end
+      else
+        initialize_raw
+      end
+    end
+  end
+end

--- a/gtk4/lib/gtk4/clipboard.rb
+++ b/gtk4/lib/gtk4/clipboard.rb
@@ -1,0 +1,25 @@
+# Copyright (C) 2015  Ruby-GNOME2 Project Team
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+
+module Gtk
+  class Clipboard
+    alias_method :set_text_raw, :set_text
+    def set_text(text)
+      set_text_raw(text, text.bytesize)
+    end
+    alias_method :text=, :set_text
+  end
+end

--- a/gtk4/lib/gtk4/color-chooser-dialog.rb
+++ b/gtk4/lib/gtk4/color-chooser-dialog.rb
@@ -1,0 +1,27 @@
+# Copyright (C) 2015  Ruby-GNOME2 Project Team
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+
+module Gtk
+  class ColorChooserDialog
+    alias_method :initialize_raw, :initialize
+    def initialize(options={})
+      title = options[:title]
+      parent = options[:parent]
+
+      initialize_raw(title, parent)
+    end
+  end
+end

--- a/gtk4/lib/gtk4/combo-box-text.rb
+++ b/gtk4/lib/gtk4/combo-box-text.rb
@@ -1,0 +1,30 @@
+# Copyright (C) 2015  Ruby-GNOME2 Project Team
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+
+module Gtk
+  class ComboBoxText
+    alias_method :initialize_raw, :initialize
+    def initialize(options={})
+      entry = options[:entry]
+
+      if entry
+        initialize_new_with_entry
+      else
+        initialize_new
+      end
+    end
+  end
+end

--- a/gtk4/lib/gtk4/combo-box.rb
+++ b/gtk4/lib/gtk4/combo-box.rb
@@ -1,0 +1,55 @@
+# Copyright (C) 2015  Ruby-GNOME2 Project Team
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+
+module Gtk
+  class ComboBox
+    alias_method :initialize_raw, :initialize
+    def initialize(options={})
+      entry = options[:entry]
+      model = options[:model]
+      area  = options[:area]
+
+      if entry
+        if model
+          initialize_new_with_model_and_entry(model)
+        elsif area
+          initialize_new_with_area_and_entry(area)
+        else
+          initialize_new_with_entry
+        end
+      else
+        if model
+          initialize_new_with_model(model)
+        elsif area
+          initialize_new_with_area(area)
+        else
+          initialize_new
+        end
+      end
+    end
+
+    alias_method :active_iter_raw, :active_iter
+    def active_iter
+      found, iter = active_iter_raw
+      if found
+        iter.model = model
+        iter
+      else
+        nil
+      end
+    end
+  end
+end

--- a/gtk4/lib/gtk4/container.rb
+++ b/gtk4/lib/gtk4/container.rb
@@ -1,0 +1,62 @@
+# Copyright (C) 2014-2015  Ruby-GNOME2 Project Team
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+
+module Gtk
+  class Container
+    alias_method :add_raw, :add
+    def add(child, properties={})
+      child.freeze_child_notify
+      begin
+        add_raw(child)
+        properties.each do |key, value|
+          child_set_property(child, key, value)
+        end
+        self
+      ensure
+        child.thaw_child_notify
+      end
+    end
+    alias_method :<<, :add
+
+    def add_child(*args)
+      if args.size == 1
+        add(*args)
+      else
+        super
+      end
+    end
+
+    alias_method :remove_child, :remove
+
+    alias_method :focus_chain_raw, :focus_chain
+    def focus_chain
+      set_explicitly, widgets = focus_chain_raw
+      if set_explicitly
+        widgets
+      else
+        nil
+      end
+    end
+
+    alias_method :child_get_property_raw, :child_get_property
+    def child_get_property(child, name)
+      property = self.class.find_child_property(name)
+      value = GLib::Value.new(property.value_type)
+      child_get_property_raw(child, name, value)
+      value.value
+    end
+  end
+end

--- a/gtk4/lib/gtk4/css-provider.rb
+++ b/gtk4/lib/gtk4/css-provider.rb
@@ -1,0 +1,47 @@
+# Copyright (C) 2014-2015  Ruby-GNOME2 Project Team
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+
+module Gtk
+  class CssProvider
+    def load(options)
+      data = options[:data]
+      file = options[:file]
+      path = options[:path]
+      resource_path = options[:resource_path]
+      if data
+        load_from_data(data)
+      elsif file
+        load_from_file(file)
+      elsif path
+        load_from_path(path)
+      elsif resource_path
+        load_from_resource(resource_path)
+      else
+        message = "Must specify one of :data, :file, :path or :resource_path"
+        raise ArgumentError, "#{message}: #{options.inspect}"
+      end
+    end
+
+    alias_method :load_from_data_raw, :load_from_data
+    def load_from_data(data)
+      if data.is_a?(GLib::Bytes)
+        load_from_data_raw(data.to_s)
+      else
+        load_from_data_raw(data)
+      end
+    end
+  end
+end

--- a/gtk4/lib/gtk4/deprecated.rb
+++ b/gtk4/lib/gtk4/deprecated.rb
@@ -1,0 +1,1131 @@
+module Gtk
+  extend GLib::Deprecatable
+  define_deprecated_const :Allocation, "Gdk::Rectangle"
+
+  define_deprecated_const :Combo,                  :raise => "Use 'Gtk::ComboBoxText' instead."
+  define_deprecated_const :ComboBoxEntry,          :raise => "Use 'Gtk::ComboBox' instead."
+  define_deprecated_const :Curve,                  :raise => "Don't use this widget anymore."
+  define_deprecated_const :FileSelection,          :raise => "Use 'Gtk::FileChooserDialog' instead."
+  define_deprecated_const :FontSelection,          :raise => "Use 'Gtk::FontChooserWidget' instead."
+  define_deprecated_const :FontSelectionDialog,    :raise => "Use 'Gtk::FontChooserDialog' instead."
+  remove_const(:ColorSelection)
+  define_deprecated_const :ColorSelection,         :raise => "Use 'Gtk::ColorChooserWidget' instead."
+  remove_const(:ColorSelectionDialog)
+  define_deprecated_const :ColorSelectionDialog,   :raise => "Use 'Gtk::ColorChooserDialog' instead."
+  define_deprecated_const :GammaCurve,             :raise => "Don't use this widget anymore."
+  define_deprecated_const :HRuler,                 :raise => "Don't use this widget anymore."
+  define_deprecated_const :InputDialog,            :raise => "Don't use this widget anymore."
+  define_deprecated_const :ItemFactory,            :raise => "Use 'Gtk::UIManager' instead."
+  define_deprecated_const :OptionMenu,             :raise => "Use 'Gtk::ComboBox' instead."
+  define_deprecated_const :PageSetupUnixDialog,    :raise => "Use 'Gtk::PrintOperation' instead."
+  define_deprecated_const :Printer,                :raise => "Use 'Gtk::PrintOperation' instead."
+  define_deprecated_const :PrintCapabilities,      :raise => "Use 'Gtk::PrintOperation' instead."
+  define_deprecated_const :PrintJob,               :raise => "Use 'Gtk::PrintOperation' instead."
+  define_deprecated_const :PrintUnixDialog,        :raise => "Use 'Gtk::PrintOperation' instead."
+  define_deprecated_const :RC,                     :raise => "Use 'Gtk::StyleContext' instead."
+  define_deprecated_const :RcStyle,                :raise => "Use 'Gtk::CssProvider' instead."
+  define_deprecated_const :Ruler,                  :raise => "Don't use this widget anymore."
+  define_deprecated_const :Style,                  :raise => "Use 'Gtk::StyleContext' instead."
+  define_deprecated_const :Tooltips,               :raise => "Use 'Gtk::Tooltip' API."
+  define_deprecated_const :VRuler,                 :raise => "Don't use this widget anymore."
+  define_deprecated_flags :AccelFlags, 'ACCEL'
+  define_deprecated_flags :AttachOptions
+  define_deprecated_enums :CornerType, 'CORNER'
+  define_deprecated_enums :DeleteType, 'DELETE'
+  define_deprecated_enums :DirectionType, 'DIR'
+  define_deprecated_enums :ExpanderStyle, 'EXPANDER'
+  define_deprecated_enums :Justification, 'JUSTIFY'
+  define_deprecated_enums :MovementStep, 'MOVEMENT'
+  define_deprecated_enums :Orientation, 'ORIENTATION'
+  define_deprecated_enums :PackType, 'PACK'
+  define_deprecated_enums :PathPriorityType, 'PATH_PRIO'
+  define_deprecated_enums :PathType, 'PATH'
+  define_deprecated_enums :PolicyType, 'POLICY'
+  define_deprecated_enums :PositionType, 'POS'
+  define_deprecated_enums :ReliefStyle, 'RELIEF'
+  define_deprecated_enums :ResizeMode, 'RESIZE'
+  define_deprecated_enums :ScrollStep, 'SCROLL'
+  define_deprecated_enums :ScrollType, 'SCROLL'
+  define_deprecated_enums :SelectionMode, 'SELECTION'
+  define_deprecated_enums :ShadowType, 'SHADOW'
+  define_deprecated_enums :StateType, 'STATE'
+  define_deprecated_enums :SortType, 'SORT'
+  define_deprecated_const :AnchorType
+  define_deprecated_const :ANCHOR_CENTER
+  define_deprecated_const :ANCHOR_NORTH
+  define_deprecated_const :ANCHOR_NORTH_WEST
+  define_deprecated_const :ANCHOR_NORTH_EAST
+  define_deprecated_const :ANCHOR_SOUTH
+  define_deprecated_const :ANCHOR_SOUTH_WEST
+  define_deprecated_const :ANCHOR_SOUTH_EAST
+  define_deprecated_const :ANCHOR_WEST
+  define_deprecated_const :ANCHOR_EAST
+  define_deprecated_const :ANCHOR_N
+  define_deprecated_const :ANCHOR_NW
+  define_deprecated_const :ANCHOR_NE
+  define_deprecated_const :ANCHOR_S
+  define_deprecated_const :ANCHOR_SW
+  define_deprecated_const :ANCHOR_SE
+  define_deprecated_const :ANCHOR_W
+  define_deprecated_const :ANCHOR_E
+  define_deprecated_const :UpdateType
+  define_deprecated_const :UPDATE_CONTINUOUS
+  define_deprecated_const :UPDATE_DISCONTINUOUS
+  define_deprecated_const :UPDATE_DELAYED
+  define_deprecated_singleton_method :init_add, :warn => "Don't use this method."
+  define_deprecated_singleton_method :quit_add, :warn => "Don't use this method."
+  define_deprecated_singleton_method :quit_remove, :warn => "Don't use this method."
+  define_deprecated_singleton_method :get_event_widget, :warn => "Use 'Gdk::Event#widget'." do |_self, event|
+    event && event.widget
+  end
+  define_deprecated_singleton_method :timeout_add, :warn => "Use 'GLib::Timeout.add'." do |_self, interval, &block|
+    GLib::Timeout.add(interval, &block)
+  end
+  define_deprecated_singleton_method :timeout_remove, :warn => "Use 'GLib::Source.remove'." do |_self, id|
+    GLib::Source.remove(id)
+  end
+  define_deprecated_singleton_method :idle_add, :warn => "Use 'GLib::Idle.add'." do |_self, &block|
+    GLib::Idle.add(&block)
+  end
+  define_deprecated_singleton_method :idle_add_priority, :warn => "Use 'GLib::Idle.add'." do |_self, priority, &block|
+    GLib::Idle.add(priority, &block)
+  end
+  define_deprecated_singleton_method :idle_remove, :warn => "Use 'GLib::Source.remove'." do |_self, id|
+    GLib::Source.remove(id)
+  end
+  define_deprecated_singleton_method :grab_add, :warn => "Use 'Gtk::Widget#grab_add'." do |_self, widget|
+    widget.grab_add
+  end
+  define_deprecated_singleton_method :grab_remove, :warn => "Use 'Gtk::Widget#grab_remove'." do |_self, widget|
+    widget.grab_remove
+  end
+
+  class AboutDialog
+    extend GLib::Deprecatable
+    define_deprecated_singleton_method :set_email_hook, :warn => "Use 'activate-link' signal."
+    define_deprecated_singleton_method :set_url_hook, :warn => "Use 'activate-link' signal."
+  end
+
+  class Action
+    extend GLib::Deprecatable
+    define_deprecated_method :connect_proxy, :warn => "Use 'Gtk::Activatable#set_related_action'."
+    define_deprecated_method :disconnect_proxy, :warn => "Use 'Gtk::Activatable#set_related_action'."
+    define_deprecated_method :block_activate_from, :warn => "Don't use this method."
+    define_deprecated_method :unblock_activate_from, :warn => "Don't use this method."
+    define_deprecated_method_by_hash_args :initialize,
+        'name, label, tooltip = nil, stock_id = nil',
+        'name, :label => nil, :tooltip => nil, :stock_id => nil', 1 do
+        |_self, name, label, tooltip, stock_id|
+      [name, {:label => label, :tooltip => tooltip, :stock_id => stock_id}]
+    end
+  end
+
+  class Alignment
+    extend GLib::Deprecatable
+    define_deprecated_const :Align, "Gtk::Align"
+  end
+
+  class Arrow
+    extend GLib::Deprecatable
+    define_deprecated_enums :Type
+  end
+
+  class Assistant
+    extend GLib::Deprecatable
+    define_deprecated_const :PageType, "Gtk::AssistantPageType"
+    define_deprecated_enums :AssistantPageType, 'PAGE'
+    define_deprecated_method :set_page_header_image, :warn => "Don't use this method."
+    define_deprecated_method :get_page_header_image, :warn => "Don't use this method."
+    define_deprecated_method :set_page_side_image, :warn => "Don't use this method."
+    define_deprecated_method :get_page_side_image, :warn => "Don't use this method."
+  end
+
+  class BindingSet
+    extend GLib::Deprecatable
+    define_deprecated_method :entry_clear, :remove
+    define_deprecated_method :entry_skip, :skip
+    define_deprecated_method :entry_add_signal, :add_signal
+    define_deprecated_method :add_path, :raise => "Don't use this method."
+  end
+
+  class Box
+    extend GLib::Deprecatable
+    define_deprecated_method :pack_start_defaults, :pack_start
+    define_deprecated_method :pack_end_defaults, :pack_end
+    define_deprecated_method_by_hash_args :pack_start,
+        'child, expand = true, fill = true, padding = 0',
+        'child, :expand => true, :fill => true, :padding => 0', 1 do
+        |_self, child, expand, fill, padding|
+      [child, {:expand => expand, :fill => fill, :padding => padding}]
+    end
+    define_deprecated_method_by_hash_args :pack_end,
+        'child, expand = true, fill = true, padding = 0',
+        'child, :expand => true, :fill => true, :padding => 0', 1 do
+        |_self, child, expand, fill, padding|
+      [child, {:expand => expand, :fill => fill, :padding => padding}]
+    end
+    define_deprecated_method_by_hash_args :set_child_packing,
+        'child, expand, fill, padding, pack_type',
+        'child, :expand => nil, :fill => nil, :padding => nil, :pack_type => nil', 1 do
+        |_self, child, expand, fill, padding, pack_type|
+      [child, {:expand => expand, :fill => fill, :padding => padding, :pack_type => pack_type}]
+    end
+  end
+
+  class Button
+    extend GLib::Deprecatable
+    define_deprecated_method :enter, :warn => "Don't use this method."
+    define_deprecated_method :leave, :warn => "Don't use this method."
+    define_deprecated_method :pressed, :warn => "Don't use this method."
+    define_deprecated_method :released, :warn => "Don't use this method."
+    define_deprecated_signal :enter, :warn => "Use 'Gtk::Widget::enter-notify-event' signal."
+    define_deprecated_signal :leave, :warn => "Use 'Gtk::Widget::leave-notify-event' signal."
+    define_deprecated_signal :pressed, :warn => "Use 'Gtk::Widget::button-press-event' signal."
+    define_deprecated_signal :released, :warn => "Use 'Gtk::Widget::button-release-event' signal."
+    define_deprecated_method_by_hash_args :initialize,
+        'label_or_stock_id, use_underline = nil',
+        ':label => nil, :use_underline => nil, :stock_id => nil' do
+        |_self, label_or_stock_id, use_underline|
+      case label_or_stock_id
+      when String
+        [{:label => label_or_stock_id, :use_underline => use_underline}]
+      when Symbol
+        [{:stock_id => label_or_stock_id}]
+      else
+        [label_or_stock_id]
+      end
+    end
+  end
+
+  class ButtonBox
+    extend GLib::Deprecatable
+    define_deprecated_const :Style, "Gtk::ButtonBoxStyle"
+    define_deprecated_enums "Gtk::ButtonBoxStyle", "STYLE"
+  end
+
+  class Calendar
+    extend GLib::Deprecatable
+    define_deprecated_flags "Gtk::CalendarDisplayOptions"
+    define_deprecated_method :freeze, :warn => "Don't use this method."
+    define_deprecated_method :thaw, :warn => "Don't use this method."
+  end
+
+  class CellRenderer
+    extend GLib::Deprecatable
+    define_deprecated_const :Mode, "Gtk::CellRendererMode"
+    define_deprecated_enums :CellRendererMode, 'MODE'
+    define_deprecated_const :State, "Gtk::CellRendererState"
+    define_deprecated_flags :CellRendererState
+    define_deprecated_method :editing_canceled, :warn => "Use '#{self}#stop_editing'." do |_self|
+      _self.stop_editing(true)
+    end
+    define_deprecated_method :get_size, :raise => "Use Gtk::CellRenderer#get_preferred_size."
+  end
+
+  class CellRendererAccel
+    extend GLib::Deprecatable
+    define_deprecated_const :Mode, "Gtk::CellRendererAccelMode"
+    define_deprecated_enums :CellRendererAccelMode, 'MODE'
+  end
+
+  class CellView
+    extend GLib::Deprecatable
+    define_deprecated_method :cell_renderers, :warn => "Use 'Gtk::CellLayout#cells'." do |_self|
+      _self.cells
+    end
+    define_deprecated_method :get_size_of_row, :raise => "Use Gtk::Widget#get_preferred_size."
+  end
+
+  class CheckMenuItem
+    extend GLib::Deprecatable
+    define_deprecated_method_by_hash_args :initialize,
+        "label, use_underline=false",
+        ":label => label, :use_underline => use_underline" do |_self, label, use_underline|
+      [{:label => label, :use_underline => use_underline}]
+    end
+  end
+
+  class ComboBox
+    extend GLib::Deprecatable
+    define_deprecated_method :append_text, :raise => "Use 'Gtk::ComboBoxText#append_text'."
+    define_deprecated_method :insert_text, :raise => "Use 'Gtk::ComboBoxText#insert_text'."
+    define_deprecated_method :prepend_text, :raise => "Use 'Gtk::ComboBoxText#prepend_text'."
+    define_deprecated_method :remove_text, :raise => "Use 'Gtk::ComboBoxText#remove'."
+    define_deprecated_method :active_text, :raise => "Use 'Gtk::ComboBoxText#active_text'."
+    define_deprecated_method_by_hash_args :initialize,
+        'model', ':entry => false, :model => nil, :area => nil' do |_self, model|
+      case model
+      when TreeModel
+        [{:model => model}]
+      when true, false
+        raise GLib::DeprecatedError.new("#{caller[0]}: '#{self}#initialize(is_text_only)' style has been deprecated. Use 'Gtk::ComboBoxText'.")
+      end
+    end
+  end
+
+  class Container
+    extend GLib::Deprecatable
+    define_deprecated_singleton_method :child_property, :find_child_property
+    define_deprecated_method :each_forall, :each_all
+  end
+
+  class Dialog
+    extend GLib::Deprecatable
+    define_deprecated_const :Flags, "Gtk::DialogFlags"
+    define_deprecated_flags :DialogFlags
+    define_deprecated_const :ResponseType, 'Gtk::ResponseType'
+    define_deprecated_enums 'Gtk::ResponseType', 'RESPONSE'
+    define_deprecated_method :vbox, :child
+    define_deprecated_method_by_hash_args :initialize,
+        'title, parent, flags, *buttons',
+        ':title => nil, :parent => nil, :flags => 0, :buttons => nil' do
+        |_self, title, parent, flags, *buttons|
+      [{:title => title, :parent => parent, :flags => flags, :buttons => buttons}]
+    end
+  end
+
+  module Drag
+    extend GLib::Deprecatable
+    define_deprecated_const :DestDefaults, "Gtk::DestDefaults"
+    define_deprecated_const :TargetFlags, "Gtk::TargetFlags"
+    define_deprecated_singleton_method :finish, :warn => "Use 'Gdk::DragContext#finish'." do |_self, context, success, del, time|
+      context.finish(:success => success,
+                     :delete => delete,
+                     :time => time)
+    end
+    define_deprecated_singleton_method :set_icon_default, :warn => "Use 'Gdk::DragContext#set_icon_default'." do |_self, context|
+      context.set_icon_default
+    end
+    define_deprecated_singleton_method :set_icon_name, :warn => "Use 'Gdk::DragContext#set_icon'." do |_self, context, name, hot_x, hot_y|
+      context.set_icon(:name => name, :hot_x => hot_x, :hot_y => hot_y)
+    end
+    define_deprecated_singleton_method :set_icon, :warn => "Use 'Gdk::DragContext#set_icon'." do |_self, context, icon, hot_x, hot_y|
+      case icon
+      when Symbol
+        context.set_icon(:stock_id => icon, :hot_x => hot_x, :hot_y => hot_y)
+      when GdkPixbuf::Pixbuf
+        context.set_icon(:pixbuf => icon, :hot_x => hot_x, :hot_y => hot_y)
+      when Gtk::Widget
+        context.set_icon(:widget => icon, :hot_x => hot_x, :hot_y => hot_y)
+      end
+    end
+    define_deprecated_singleton_method :dest_set,
+        :warn => "Use 'Gtk::Widget#drag_dest_set'." do |_self, widget, flags, targets, actions|
+      widget.drag_dest_set(flags, targets, actions)
+    end
+    define_deprecated_singleton_method :dest_set_proxy,
+        :warn => "Use 'Gtk::Widget#drag_dest_set_proxy'." do |_self, widget, proxy_window, protocol, use_coordinates|
+      widget.drag_dest_set_proxy(proxy_window, protocol, use_coordinates)
+    end
+    define_deprecated_singleton_method :dest_unset,
+        :warn => "Use 'Gtk::Widget#drag_dest_unset'." do |_self, widget|
+      widget.drag_dest_unset
+    end
+    define_deprecated_singleton_method :dest_find_target,
+        :warn => "Use 'Gtk::Widget#drag_dest_find_target'." do |_self, widget, context, target_list|
+      widget.drag_dest_find_target(context, target_list)
+    end
+    define_deprecated_singleton_method :dest_get_target_list,
+        :warn => "Use 'Gtk::Widget#drag_dest_get_target_list'." do |_self, widget|
+      widget.drag_dest_get_target_list
+    end
+    define_deprecated_singleton_method :dest_set_target_list,
+        :warn => "Use 'Gtk::Widget#drag_dest_set_target_list'." do |_self, widget, target_list|
+      widget.drag_dest_set_target_list(target_list)
+    end
+    define_deprecated_singleton_method :dest_add_text_targets,
+        :warn => "Use 'Gtk::Widget#drag_dest_add_text_targets'." do |_self, widget|
+      widget.drag_dest_add_text_targets
+    end
+    define_deprecated_singleton_method :dest_add_image_targets,
+        :warn => "Use 'Gtk::Widget#drag_dest_add_image_targets'." do |_self, widget|
+      widget.drag_dest_add_image_targets
+    end
+    define_deprecated_singleton_method :dest_add_uri_targets,
+        :warn => "Use 'Gtk::Widget#drag_dest_add_uri_targets'." do |_self, widget|
+      widget.drag_dest_add_uri_targets
+    end
+    define_deprecated_singleton_method :dest_set_track_motion,
+        :warn => "Use 'Gtk::Widget#drag_dest_set_track_motion'." do |_self, widget, track_motion|
+      widget.drag_dest_set_track_motion(track_motion)
+    end
+    define_deprecated_singleton_method :dest_get_track_motion,
+        :warn => "Use 'Gtk::Widget#drag_dest_get_track_motion'." do |_self, widget|
+      widget.drag_dest_get_track_motion
+    end
+    define_deprecated_singleton_method :get_data,
+        :warn => "Use 'Gtk::Widget#drag_get_data'." do |_self, widget, context, target, time|
+      widget.drag_get_data(context, target, time)
+    end
+    define_deprecated_singleton_method :highlight,
+        :warn => "Use 'Gtk::Widget#drag_highlight'." do |_self, widget|
+      widget.drag_highlight
+    end
+    define_deprecated_singleton_method :unhighlight,
+        :warn => "Use 'Gtk::Widget#drag_unhighlight'." do |_self, widget|
+      widget.drag_unhighlight
+    end
+    define_deprecated_singleton_method :begin,
+        :warn => "Use 'Gtk::Widget#drag_begin'." do |_self, widget, target_list, actions, button, event|
+      widget.drag_begin(target_list, actions, button, event)
+    end
+    define_deprecated_singleton_method :threshold?,
+        :warn => "Use 'Gtk::Widget#drag_threshold?'." do |_self, widget, start_x, start_y, current_x, current_y|
+      widget.drag_threshold?(start_x, start_y, current_x, current_y)
+    end
+    define_deprecated_singleton_method :source_set,
+        :warn => "Use 'Gtk::Widget#drag_source_set'." do |_self, widget, start_button_mask, targets, actions|
+      widget.drag_source_set(start_button_mask, targets, actions)
+    end
+    define_deprecated_singleton_method :source_set_icon,
+        :warn => "Use 'Gtk::Widget#drag_source_set_icon(:stock_id => nil, :pixbuf => nil)'." do |_self, widget, icon|
+      case icon
+      when Symbol
+        widget.drag_source_set_icon(:stock_id => icon)
+      else
+        widget.drag_source_set_icon(:pixbuf => icon)
+      end
+    end
+    define_deprecated_singleton_method :source_set_icon_name,
+        :warn => "Use 'Gtk::Widget#drag_source_set_icon(:icon_name => nil)'." do |_self, widget, icon|
+      widget.drag_source_set_icon(:icon_name => icon)
+    end
+    define_deprecated_singleton_method :source_unset,
+        :warn => "Use 'Gtk::Widget#drag_source_unset'." do |_self, widget|
+      widget.drag_source_unset
+    end
+    define_deprecated_singleton_method :source_set_target_list,
+        :warn => "Use 'Gtk::Widget#drag_source_set_target_list'." do |_self, widget, target_list|
+      widget.drag_source_set_target_list(target_list)
+    end
+    define_deprecated_singleton_method :source_get_target_list,
+        :warn => "Use 'Gtk::Widget#drag_source_get_target_list'." do |_self, widget|
+      widget.drag_source_get_target_list
+    end
+    define_deprecated_singleton_method :source_add_text_targets,
+        :warn => "Use 'Gtk::Widget#drag_source_add_text_targets'." do |_self, widget|
+      widget.drag_source_add_text_targets
+    end
+    define_deprecated_singleton_method :source_add_image_targets,
+        :warn => "Use 'Gtk::Widget#drag_source_add_image_targets'." do |_self, widget|
+      widget.drag_source_add_image_targets
+    end
+    define_deprecated_singleton_method :source_add_uri_targets,
+        :warn => "Use 'Gtk::Widget#drag_source_add_uri_targets'." do |_self, widget|
+      widget.drag_source_add_uri_targets
+    end
+  end
+
+  module FileChooser
+    extend GLib::Deprecatable
+    define_deprecated_const :Action, "Gtk::FileChooserAction"
+    define_deprecated_enums :FileChooserAction, 'ACTION'
+    define_deprecated_const :Confirmation, "Gtk::FileChooserConfirmation"
+    define_deprecated_enums :FileChooserConfirmation, 'CONFIRMATION'
+  end
+
+  class FileChooserDialog
+    extend GLib::Deprecatable
+    define_deprecated_method_by_hash_args :initialize,
+        'title, parent, action, back, *buttons',
+        ':title => nil, :parent => nil, :action => :open, :buttons => nil' do
+        |_self, title, parent, action, back, *buttons|
+      options = {
+          :title => title,
+          :parent => parent,
+          :action => action,
+          :buttons => buttons,
+      }
+      [options]
+    end
+  end
+
+  class FileFilter
+    extend GLib::Deprecatable
+    define_deprecated_const :Flags, "Gtk::FileFilterFlags"
+    define_deprecated_flags :FileFilterFlags
+  end
+
+  class HBox
+    extend GLib::Deprecatable
+    define_deprecated_singleton_method :new, :warn => "Use 'Gtk::Box.new(:horizontal, spacing)'." do |_self, homogeneous, spacing|
+      box = Gtk::Box.new(:horizontal, spacing)
+      box.set_homogeneous(homogeneous)
+      box
+    end
+  end
+
+  class HButtonBox
+    extend GLib::Deprecatable
+    define_deprecated_singleton_method :new, :warn => "Use 'Gtk::ButtonBox.new(:horizontal)'." do |_self|
+      Gtk::ButtonBox.new(:horizontal)
+    end
+  end
+
+  class HPaned
+    extend GLib::Deprecatable
+    define_deprecated_singleton_method :new, :warn => "Use 'Gtk::Paned.new(:horizontal)'." do |_self|
+      Gtk::Paned.new(:horizontal)
+    end
+  end
+
+  class HScale
+    extend GLib::Deprecatable
+    define_deprecated_singleton_method :new, :warn => "Use 'Gtk::Scale.new(:horizontal, *args)'." do |_self, *args|
+      Gtk::Scale.new(:horizontal, *args)
+    end
+  end
+
+  class HScrollbar
+    extend GLib::Deprecatable
+    define_deprecated_singleton_method :new, :warn => "Use 'Gtk::Scrollbar.new(:horizontal, adjustment)'." do |_self, adjustment|
+      Gtk::Scrollbar.new(:horizontal, adjustment)
+    end
+  end
+
+  class HSeparator
+    extend GLib::Deprecatable
+    define_deprecated_singleton_method :new, :warn => "Use 'Gtk::Separator.new(:horizontal)'." do |_self|
+      Gtk::Separator.new(:horizontal)
+    end
+  end
+
+  class IconSet
+    extend GLib::Deprecatable
+    define_deprecated_method :render_icon, :raise => "Use '#{self}#render_icon_pixbuf'."
+  end
+
+  class IconSize
+   extend GLib::Deprecatable
+   define_deprecated_const :IconSize, "Gtk::IconSize"
+  end
+
+  class IconTheme
+    extend GLib::Deprecatable
+    define_deprecated_const :LookupFlags, "Gtk::IconLookupFlags"
+    define_deprecated_flags :IconLookupFlags, 'LOOKUP'
+  end
+
+  class IconView
+    extend GLib::Deprecatable
+    define_deprecated_enums :IconViewDropPosition
+  end
+
+  class Image
+    extend GLib::Deprecatable
+    define_deprecated_const :Type, "Gtk::ImageType"
+    define_deprecated_enums :ImageType
+    define_deprecated_method :set, :warn => "Use '#{self}#set_stock', '#{self}#set_icon_name', '#{self}#set_icon_set', '#{self}#set_file', '#{self}#set_pixbuf' or '#{self}#set_pixbuf_animation'."
+    define_deprecated_method_by_hash_args :initialize,
+        'image, size = nil',
+        ':stock => nil, :icon_name => nil, :icon_set => nil, :icon => nil, :file => nil, :pixbuf => nil, :animation => nil, :surface => nil, :size => nil' do
+        |_self, image, size|
+      case image
+      when String
+        if size
+          [{:icon_name => image, :size => size}]
+        else
+          [{:file => image}]
+        end
+      when Symbol
+        [{:stock => image, :size => size}]
+      when GdkPixbuf::Pixbuf
+        [{:pixbuf => image}]
+      when Gtk::IconSet
+        [{:icon_set => image, :size => size}]
+      when Gio::Icon
+        [{:icon => image, :size => size}]
+      else
+        message =
+          "Image must be String, Symbol, GdkPixbuf::Pixbuf, Gtk::IconSet or " +
+          "Gio::Icon: #{image.inspect}"
+        raise ArgumentError, message
+      end
+    end
+  end
+
+  class ImageMenuItem
+    extend GLib::Deprecatable
+    define_deprecated_method_by_hash_args :initialize,
+        'label_or_stock_id = nil, use_underline_or_accel_group = nil',
+        ':label => nil, :mnemonic => nil, :stock_id => nil, :accel_group => nil' do
+        |_self, label_or_stock_id, use_underline_or_accel_group|
+      case label_or_stock_id
+      when String
+        if use_underline_or_accel_group
+          [{:mnemonic => label_or_stock_id}]
+        else
+          [{:label => label_or_stock_id}]
+        end
+      when Symbol
+        [{:stock_id => label_or_stock_id, :accel_group => use_underline_or_accel_group}]
+      end
+    end
+  end
+
+  class LinkButton
+    extend GLib::Deprecatable
+    define_deprecated_singleton_method :set_uri_hook, :warn => "Use 'clicked' signal."
+  end
+
+  class MenuBar
+    extend GLib::Deprecatable
+    define_deprecated_enums :PackDirection, 'PACK_DIRECTION'
+  end
+
+  class MenuItem
+    extend GLib::Deprecatable
+
+    define_deprecated_method_by_hash_args :initialize,
+        "label, use_underline=false",
+        ":label => label, :use_underline => use_underline" do |_self, label, use_underline|
+      [{:label => label, :use_underline => use_underline}]
+    end
+
+    define_deprecated_method :remove_submenu, :warn => "Use '#{self}#set_submenu'." do |_self|
+      _self.set_submenu(nil)
+    end
+  end
+
+  class MenuShell
+    extend GLib::Deprecatable
+    define_deprecated_enums :DirectionType, 'DIR'
+  end
+
+  class MenuToolButton
+    extend GLib::Deprecatable
+    define_deprecated_method_by_hash_args :initialize,
+        'icon_widget_or_stock_id = nil, label = nil',
+        ':icon_widget => nil, :label => nil, :stock_id => nil' do
+        |_self, icon_widget_or_stock_id, label|
+      case icon_widget_or_stock_id
+      when String, Symbol
+        [{:stock_id => icon_widget_or_stock_id}]
+      when Gtk::Widget
+        [{:icon_widget => icon_widget_or_stock_id, :label => label}]
+      end
+    end
+  end
+
+  class MessageDialog
+    extend GLib::Deprecatable
+    define_deprecated_const :ButtonsType, "Gtk::ButtonsType"
+    define_deprecated_enums "Gtk::ButtonsType", "BUTTONS"
+    define_deprecated_const :Type, 'Gtk::MessageType'
+    define_deprecated_enums 'Gtk::MessageType'
+    define_deprecated_method_by_hash_args :initialize,
+        'parent, flags, type, buttons_type, message',
+        ':parent => nil, :flags => 0, :type => :info, :buttons => :ok, :message => ""' do
+        |_self, parent, flags, type, buttons, message|
+      [{:parent => parent, :flags => flags, :type => type, :buttons => buttons, :message => message}]
+    end
+  end
+
+  class Notebook
+    extend GLib::Deprecatable
+    define_deprecated_singleton_method :set_window_creation_hook, :warn => "Use 'create-window' signal."
+    define_deprecated_method :query_tab_label_packing, :warn => "Use 'tab-expand' and 'tab-fill' child property." do |_self, child|
+      [_self.child_get_property(child, 'tab-expand'), _self.child_get_property(child, 'tab-fill')]
+    end
+    define_deprecated_method :set_tab_label_packing, :warn => "Use 'tab-expand' and 'tab-fill' child property." do |_self, child, expand, fill, pack_type|
+      _self.child_set_property(child, 'tab-expand', expand)
+      _self.child_set_property(child, 'tab-fill', fill)
+    end
+  end
+
+  class PaperSize
+    extend GLib::Deprecatable
+    define_deprecated_enums :Unit, 'UNIT'
+  end
+
+  class PrintOperation
+    extend GLib::Deprecatable
+    define_deprecated_const :Action, "Gtk::PrintOperationAction"
+    define_deprecated_enums :PrintOperationAction, 'ACTION'
+    define_deprecated_const :Result, "Gtk::PrintOperationResult"
+    define_deprecated_enums :PrintOperationResult, 'RESULT'
+    define_deprecated_const :Status, "Gtk::PrintStatus"
+    define_deprecated_enums :PrintStatus, 'STATUS'
+  end
+
+  class PrintSettings
+    extend GLib::Deprecatable
+    define_deprecated_enums :PageOrientation, 'ORIENTATION'
+    define_deprecated_enums :PageSet, 'PAGE_SET'
+    define_deprecated_enums :PrintDuplex, 'DUPLEX'
+    define_deprecated_enums :PrintPages, 'PAGES'
+    define_deprecated_enums :PrintQuality, 'QUALITY'
+  end
+
+  class Paned
+    extend GLib::Deprecatable
+    %w(child1 child2).product(%w(resize shrink)).each do |child, prop|
+      define_deprecated_method "#{child}_#{prop}?", :warn => "Use '#{prop}' child property." do |_self|
+        _self.child_get_property(_self.send(child), prop)
+      end
+    end
+    define_deprecated_method_by_hash_args :pack1,
+        'child, resize, shrink',
+        'child, :resize => false, :shrink => true', 1 do
+        |_self, child, resize, shrink|
+      [child, {:resize => resize, :shrink => shrink}]
+    end
+    define_deprecated_method_by_hash_args :pack2,
+        'child, resize, shrink',
+        'child, :resize => true, :shrink => true', 1 do
+        |_self, child, resize, shrink|
+      [child, {:resize => resize, :shrink => shrink}]
+    end
+  end
+
+  class RadioAction
+    extend GLib::Deprecatable
+    define_deprecated_method_by_hash_args :initialize,
+        'name, label, tooltip, stock_id, value',
+        'name, value, :label => nil, :tooltip => nil, :stock_id => nil', 2 do
+        |_self, name, label, tooltip, stock_id, value|
+      [name, value, {:label => label, :tooltip => tooltip, :stock_id => stock_id}]
+    end
+  end
+
+  class RadioButton
+    extend GLib::Deprecatable
+    define_deprecated_method_by_hash_args :initialize,
+        'member_or_label, label_or_use_underline, use_underline',
+        ':label => label, :member => member, :use_underline => use_underline',
+        0 do |_self, member_or_label, label_or_use_underline, use_underline|
+      options = {}
+      if member_or_label.is_a?(Gtk::RadioButton)
+        options[:member] = member_or_label
+        if label_or_use_underline.is_a?(String)
+          options[:label] = label_or_use_underline
+          options[:use_underline] = use_underline
+        end
+      else
+        options[:label] = member_or_label
+        options[:use_underline] = label_or_use_underline
+      end
+      [options]
+    end
+  end
+
+  class Range
+    extend GLib::Deprecatable
+    define_deprecated_enums :SensitivityType, 'SENSITIVITY'
+    define_deprecated_method :update_policy, :raise => "Don't use this method."
+    define_deprecated_method :set_update_policy, :warn => "Don't use this method."
+    alias :update_policy= :set_update_policy
+  end
+
+  class RecentAction
+    extend GLib::Deprecatable
+    define_deprecated_method_by_hash_args :initialize,
+        'name, label, tooltip = nil, stock_id = nil, manager = nil',
+        'name, :label => nil, :tooltip => nil, :stock_id => nil, :manager => nil', 1 do
+        |_self, name, label, tooltip, stock_id, manager|
+      [name, {:label => label, :tooltip => tooltip, :stock_id => stock_id, :manager => manager}]
+    end
+  end
+
+  module RecentChooser
+    extend GLib::Deprecatable
+    define_deprecated_enums :SortType, 'SORT'
+    define_deprecated_method :show_numbers, :warn => "Use 'Gtk::RecentChooserMenu#show_numbers?'." do |_self|
+      false
+    end
+    define_deprecated_method :set_show_numbers, :warn => "Use 'Gtk::RecentChooserMenu#set_show_numbers'."
+    alias :show_numbers= :set_show_numbers
+  end
+
+  class RecentChooserDialog
+    extend GLib::Deprecatable
+    define_deprecated_method_by_hash_args :initialize,
+        'title, parent, manager, *buttons',
+        ':title => nil, :parent => nil, ' +
+        ':recent_manager => nil, :buttons => nil' do |_self, title, parent, *buttons|
+      if buttons.first.is_a?(RecentManager)
+        recent_manager = buttons.shift
+      else
+        recent_manager = nil
+      end
+      [
+        {
+          :title          => title,
+          :parent         => parent,
+          :recent_manager => recent_manager,
+          :buttons        => buttons,
+        },
+      ]
+    end
+  end
+
+  class RecentFilter
+    extend GLib::Deprecatable
+    define_deprecated_const :Flags, "Gtk::RecentFilterFlags"
+    define_deprecated_flags :RecentFilterFlags
+  end
+
+  class RecentManager
+    extend GLib::Deprecatable
+    define_deprecated_singleton_method :get_for_screen, :warn => "Use '#{self}.default'." do |_self, screen|
+      _self.default
+    end
+    define_deprecated_method :set_screen, :warn => "Don't use this method."
+    alias :screen= :set_screen
+  end
+
+  class ProgressBar
+    extend GLib::Deprecatable
+    define_deprecated_method :set_activity_mode, :warn => "Don't use this method."
+    alias :activity_mode= :set_activity_mode
+    define_deprecated_method :activity_mode?, :warn => "Don't use this method." do |_self|
+      false
+    end
+    define_deprecated_method :set_text_xalign, :warn => "Don't use this method."
+    alias :text_xalign= :set_text_xalign
+    define_deprecated_method :text_xalign, :warn => "Don't use this method." do |_self|
+      0.0
+    end
+    define_deprecated_method :set_text_yalign, :warn => "Don't use this method."
+    alias :text_yalign= :set_text_yalign
+    define_deprecated_method :text_yalign, :warn => "Don't use this method." do |_self|
+      0.0
+    end
+  end
+
+  class SelectionData
+    extend GLib::Deprecatable
+    define_deprecated_method :type, :data_type
+  end
+
+  class SizeGroup
+    extend GLib::Deprecatable
+    define_deprecated_const :Mode, "Gtk::SizeGroupMode"
+    define_deprecated_enums :SizeGroupMode
+  end
+
+  class SpinButton
+    extend GLib::Deprecatable
+    define_deprecated_const :Type, "Gtk::SpinType"
+    define_deprecated_enums :SpinType
+    define_deprecated_const :UpdatePolicy, "Gtk::SpinButtonUpdatePolicy"
+    define_deprecated_enums :SpinButtonUpdatePolicy, 'UPDATE'
+  end
+
+  class TextAttributes
+    extend GLib::Deprecatable
+    define_deprecated_method :realized?, :warn => "Don't use this method." do |_self|
+      false
+    end
+    define_deprecated_method :set_realized, :warn => "Don't use this method."
+    alias :realized= :set_realized
+  end
+
+  class TextBuffer
+    extend GLib::Deprecatable
+    define_deprecated_method :get_iter_at_line,
+        :warn => "Use '#{self}#get_iter_at(:line => nil)'." do |_self, line|
+      _self.get_iter_at(:line => line)
+    end
+    define_deprecated_method :get_iter_at_line_offset,
+        :warn => "Use '#{self}#get_iter_at(:line => nil, :offset => nil)'." do |_self, line, offset|
+      _self.get_iter_at(:line => line, :offset => offset)
+    end
+    define_deprecated_method :get_iter_at_line_index,
+        :warn => "Use '#{self}#get_iter_at(:line => nil, :index => nil)'." do |_self, line, index|
+      _self.get_iter_at(:line => line, :index => index)
+    end
+    define_deprecated_method :get_iter_at_offset,
+        :warn => "Use '#{self}#get_iter_at(:offset => nil)'." do |_self, offset|
+      _self.get_iter_at(:offset => offset)
+    end
+    define_deprecated_method :get_iter_at_mark,
+        :warn => "Use '#{self}#get_iter_at(:mark => nil)'." do |_self, mark|
+      _self.get_iter_at(:mark => mark)
+    end
+    define_deprecated_method :get_iter_at_child_anchor,
+        :warn => "Use '#{self}#get_iter_at(:anchor => nil)'." do |_self, anchor|
+      _self.get_iter_at(:anchor => anchor)
+    end
+    define_deprecated_method :insert_pixbuf, :insert
+    define_deprecated_method :insert_child_anchor, :insert
+    define_deprecated_method :insert_with_tags, :insert
+  end
+
+  class TextIter
+    extend GLib::Deprecatable
+    define_deprecated_const :SearchFlags, "Gtk::TextSearchFlags"
+    define_deprecated_flags :TextSearchFlags, 'SEARCH'
+    define_deprecated_method :backword_visible_word_start, :backward_visible_word_start
+  end
+
+  class TextTag
+    extend GLib::Deprecatable
+    define_deprecated_const :WrapMode, "Gtk::WrapMode"
+    define_deprecated_enums "Gtk::WrapMode", "WRAP"
+  end
+
+  class TextView
+    extend GLib::Deprecatable
+    define_deprecated_enums :WindowType, 'WINDOW'
+  end
+
+  class ToggleAction
+    extend GLib::Deprecatable
+    define_deprecated_method_by_hash_args :initialize,
+        'name, label, tooltip = nil, stock_id = nil',
+        'name, :label => nil, :tooltip => nil, :stock_id => nil', 1 do
+        |_self, name, label, tooltip, stock_id|
+      [name, {:label => label, :tooltip => tooltip, :stock_id => stock_id}]
+    end
+  end
+
+  class ToggleButton
+    extend GLib::Deprecatable
+    define_deprecated_method_by_hash_args :initialize,
+        'label=nil, use_underline=nil',
+        ':label => label, :use_underline => use_underline', 0 do
+        |_self, label, use_underline|
+      [{:label => label, :use_underline => use_underline}]
+    end
+  end
+
+  class Toolbar
+    extend GLib::Deprecatable
+    define_deprecated_const :Style, "Gtk::ToolbarStyle"
+    define_deprecated_method :append, :warn => "Don't use this method."
+    define_deprecated_method :prepend, :warn => "Don't use this method."
+    define_deprecated_method :item_index, :get_item_index
+    define_deprecated_method :nth_item, :get_nth_item
+    define_deprecated_method :drop_index, :get_drop_index
+    define_deprecated_method :append_space, :warn => "Don't use this method."
+    define_deprecated_method :prepend_space, :warn => "Don't use this method."
+    define_deprecated_method :insert_space, :warn => "Don't use this method."
+    define_deprecated_method :remove_space, :warn => "Don't use this method."
+  end
+
+  class ToolButton
+    extend GLib::Deprecatable
+    define_deprecated_method_by_hash_args :initialize,
+        'icon_widget_or_stock_id = nil, label = nil',
+        ':icon_widget => nil, :label => nil, :stock_id => nil' do
+        |_self, icon_widget_or_stock_id, label|
+      case icon_widget_or_stock_id
+      when String, Symbol
+        [{:stock_id => icon_widget_or_stock_id}]
+      when Gtk::Widget
+        [{:icon_widget => icon_widget_or_stock_id, :label => label}]
+      end
+    end
+  end
+
+  class Tooltip
+    extend GLib::Deprecatable
+    define_deprecated_method :set_icon_from_stock, :warn => "Use '#{self}#set_icon'." do |_self, stock_id, size|
+      _self.set_icon(:stock_id => stock_id, :size => size)
+    end
+  end
+
+  module TreeModel
+    extend GLib::Deprecatable
+    define_deprecated_const :Flags, "Gtk::TreeModelFlags"
+    define_deprecated_flags :TreeModelFlags
+  end
+
+  class TreeSelection
+    extend GLib::Deprecatable
+    define_deprecated_method :selected_each, :each
+  end
+
+  class TreeView
+    extend GLib::Deprecatable
+    define_deprecated_const :DropPosition, "Gtk::TreeViewDropPosition"
+    define_deprecated_enums :TreeViewDropPosition, 'DROP'
+    define_deprecated_const :GridLines, "Gtk::TreeViewGridLines"
+    define_deprecated_enums :TreeViewGridLines, 'GRID_LINES'
+    define_deprecated_method :widget_to_tree_coords, :convert_widget_to_bin_window_coords
+    define_deprecated_method :tree_to_widget_coords, :convert_bin_window_to_widget_coords
+  end
+
+  class TreeViewColumn
+    extend GLib::Deprecatable
+    define_deprecated_const :Sizing, "Gtk::TreeViewColumnSizing"
+    define_deprecated_enums :TreeViewColumnSizing
+    define_deprecated_method :cell_renderers, :warn => "Use 'Gtk::CellLayout#cells'." do |_self|
+      _self.cells
+    end
+  end
+
+  class UIManager
+    extend GLib::Deprecatable
+    define_deprecated_const :ItemType, "Gtk::UIManagerItemType"
+    define_deprecated_flags :UIManagerItemType
+  end
+
+  class VBox
+    extend GLib::Deprecatable
+    define_deprecated_singleton_method :new, :warn => "Use 'Gtk::Box.new(:vertical, spacing)'." do |_self, homogeneous, spacing|
+      box = Gtk::Box.new(:vertical, spacing)
+      box.set_homogeneous(homogeneous)
+      box
+    end
+  end
+
+  class VButtonBox
+    extend GLib::Deprecatable
+    define_deprecated_singleton_method :new, :warn => "Use 'Gtk::ButtonBox.new(:vertical)'." do |_self|
+      Gtk::ButtonBox.new(:vertical)
+    end
+  end
+
+  class VPaned
+    extend GLib::Deprecatable
+    define_deprecated_singleton_method :new, :warn => "Use 'Gtk::Paned.new(:vertical)'." do |_self|
+      Gtk::Paned.new(:vertical)
+    end
+  end
+
+  class VScale
+    extend GLib::Deprecatable
+    define_deprecated_singleton_method :new, :warn => "Use 'Gtk::Scale.new(:vertical, *args)'." do |_self, *args|
+      Gtk::Scale.new(:vertical, *args)
+    end
+  end
+
+  class VScrollbar
+    extend GLib::Deprecatable
+    define_deprecated_singleton_method :new, :warn => "Use 'Gtk::Scrollbar.new(:vertical, adjustment)'." do |_self, adjustment|
+      Gtk::Scrollbar.new(:vertical, adjustment)
+    end
+  end
+
+  class VSeparator
+    extend GLib::Deprecatable
+    define_deprecated_singleton_method :new, :warn => "Use 'Gtk::Separator.new(:vertical)'." do |_self|
+      Gtk::Separator.new(:vertical)
+    end
+  end
+
+  class Widget
+    extend GLib::Deprecatable
+    define_deprecated_const :Align, "Gtk::Align"
+    define_deprecated_const :HelpType, "Gtk::WidgetHelpType"
+    define_deprecated_enums :WidgetHelpType, 'HELP'
+    define_deprecated_const :TextDirection, "Gtk::TextDIrection"
+    define_deprecated_enums "Gtk::TextDirection", 'TEXT_DIR'
+    define_deprecated_singleton_method :push_colormap, :warn => "Don't use this method."
+    define_deprecated_singleton_method :pop_colormap, :warn => "Don't use this method."
+    define_deprecated_singleton_method :set_default_colormap, :warn => "Don't use this method."
+    class << self
+      alias :default_colormap= :set_default_colormap
+    end
+    define_deprecated_singleton_method :default_colormap, :raise => "Don't use this method."
+    define_deprecated_singleton_method :default_visual, :raise => "Don't use this method."
+    define_deprecated_singleton_method :default_style, :raise => "Use 'Gtk::StyleContext' and 'Gtk::CssProvider'."
+    define_deprecated_const :Flags, :raise => "Don't use this flags anymore."
+    define_deprecated_method :flags, :raise => "Use the proper method."
+    define_deprecated_method :set_flags, :warn => "Use the proper method."
+    alias :flags= :set_flags
+    define_deprecated_method :unset_flags, :warn => "Use the proper method."
+    define_deprecated_method :get_size_request, :size_request
+    define_deprecated_method :no_window?, :warn => "Use '#{self}#has_window?'." do |_self|
+      !_self.has_window?
+    end
+    define_deprecated_method :rc_style?, :has_rc_style?
+    define_deprecated_method :parent_sensitive?, :warn => "Use '#{self}#sensitive?' on the parent widget." do |_self|
+      _self.parent.sensitive?
+    end
+    define_deprecated_method :hide_all, :hide
+    define_deprecated_method :colormap, :raise => "Use '#{self}#visual'."
+    define_deprecated_method :set_colormap, :warn => "Use '#{self}#set_visual'."
+    alias :colormap= :set_colormap
+    define_deprecated_method :shape_combine_mask, :warn => "Use '#{self}#shape_combine_region' instead."
+    define_deprecated_method :input_shape_combine_mask, :warn => "Use '#{self}#input_shape_combine_region' instead."
+    define_deprecated_method :reset_shapes, :warn => "Don't use this method."
+    define_deprecated_method :set_scroll_adjustments, :warn => "Use 'Gtk::Scrollable#set_hadjustment' and 'Gtk::Scrollable#set_vadjustment'." do |_self, hadj, vadj|
+      _self.set_hadjustment(hadj)
+      _self.set_vadjustment(vadj)
+      true
+    end
+    alias :set_scroll_adjustment :set_scroll_adjustments
+    define_deprecated_method :action, :warn => "Use 'Gtk::Activatable#related_action'." do |_self|
+      _self.related_action
+    end
+    define_deprecated_method :child_requisition, :warn => "Use '#{self}#preferred_size'." do |_self|
+      _self.preferred_size.last
+    end
+    define_deprecated_method :set_state, :warn => "Use '#{self}#set_state_flags'."
+    alias :state= :set_state
+    define_deprecated_method :ensure_style, :warn => "Use 'Gtk::StyleContext'."
+    define_deprecated_method :reset_rc_styles, :warn => "Use '#{self}#reset_style'."
+    define_deprecated_method :class_path, :raise => "Use '#{self}#widget_path'."
+    define_deprecated_method :modify_style, :warn => "Use 'Gtk::StyleContext'."
+    define_deprecated_method :modifier_style, :raise => "Use 'Gtk::StyleContext'."
+    define_deprecated_method :modify_fg, :warn => "Use '#{self}#override_color'."
+    define_deprecated_method :modify_bg, :warn => "Use '#{self}#override_background_color'."
+    define_deprecated_method :modify_text, :warn => "Use '#{self}#override_color'."
+    define_deprecated_method :modify_base, :warn => "Use '#{self}#override_background_color'."
+    define_deprecated_method :modify_font, :warn => "Use '#{self}#override_font'."
+    define_deprecated_method :modify_cursor, :warn => "Use '#{self}#override_cursor'."
+    define_deprecated_method :render_icon, :warn => "Use '#{self}#render_icon_pixbuf'." do |_self, stock_id, size, detail|
+      _self.render_icon_pixbuf(stock_id, size)
+    end
+    define_deprecated_method :state, :raise => "Use '#{self}#state_flags'."
+    define_deprecated_method :has_rc_style?, :warn => "Use 'Gtk::StyleContext'." do |_self|
+      false
+    end
+    define_deprecated_method :requisition, :raise => "Don't use this method."
+    define_deprecated_method :set_requisition, :warn => "Don't use this method."
+    define_deprecated_method :saved_state, :raise => "Don't use this method."
+    define_deprecated_method :pointer, :raise => "Use 'Gdk::Window#get_device_position'."
+
+    alias :__set_allocation__ :set_allocation
+    private :__set_allocation__
+    def set_allocation(*args)
+      case args.size
+      when 1
+        __set_allocation__(args.first)
+      when 4
+        warn "#{caller[0]}: '#{self.class}#set_allocation(x, y, width, height)' style has been deprecated. Use '#{self.class}#set_allocation(alloc)' style."
+        __set_allocation__(Gtk::Allocation.new(*args))
+      else
+        raise ArgumentError.new("need 1 or 4 arguments.")
+      end
+    end
+
+    define_deprecated_signal :expose_event, :warn => "Use '#{self}::draw' signal."
+    define_deprecated_signal :state_changed, :warn => "Use '#{self}::state-flags-changed' signal."
+    define_deprecated_signal :style_set, :warn => "Use '#{self}::style-updated' signal."
+  end
+
+  class Window
+    extend GLib::Deprecatable
+    define_deprecated_const :Position, "Gtk::WindowPosition"
+    define_deprecated_enums "Gtk::WindowPosition", 'POS'
+    define_deprecated_const :Type, "Gtk::WindowType"
+    define_deprecated_enums "Gtk::WindowType"
+    define_deprecated_method :active_focus, :activate_focus
+    define_deprecated_method :active_default, :activate_default
+  end
+
+  class RecentFilter
+    extend GLib::Deprecatable
+    define_deprecated_const :Flags, 'Gtk::RecentFilterFlags'
+  end
+end
+
+module Gdk
+  class DragContext
+    define_deprecated_method_by_hash_args :finish,
+        'success, delete, time',
+        ':success => true, :delete => false, :time => Gdk::CURRENT_TIME' do |_self, success, delete, time|
+      [{:success => success, :delete => delete, :time => time}]
+    end
+  end
+
+  class Event
+    define_deprecated_method :event_widget, :warn => "Use 'Gdk::Event#widget'." do |_self|
+      _self.widget
+    end
+  end
+end

--- a/gtk4/lib/gtk4/dialog.rb
+++ b/gtk4/lib/gtk4/dialog.rb
@@ -1,0 +1,83 @@
+# Copyright (C) 2015-2016  Ruby-GNOME2 Project Team
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+
+module Gtk
+  class Dialog
+    alias_method :initialize_raw, :initialize
+    def initialize(options={})
+      initialize_raw
+
+      title   = options[:title]
+      parent  = options[:parent]
+      flags   = options[:flags]
+      buttons = options[:buttons]
+
+      set_title(title) if title
+      set_transient_for(parent) if parent
+      if flags
+        unless flags.is_a?(DialogFlags)
+          flags = DialogFlags.new(flags)
+        end
+        set_modal(true) if flags.modal?
+        set_destroy_with_parent(true) if flags.destroy_with_parent?
+      end
+
+      add_buttons(*buttons) if buttons
+    end
+
+    alias_method :run_raw, :run
+    def run
+      response_id = run_raw
+      if response_id < 0
+        ResponseType.new(response_id)
+      else
+        response_id
+      end
+    end
+
+    def add_buttons(*buttons)
+      buttons.each do |text, response_id|
+        add_button(text, response_id)
+      end
+    end
+
+    alias_method :add_button_raw, :add_button
+    def add_button(text, response_id)
+      case response_id
+      when Symbol
+        response_id = ResponseType.new(response_id)
+      end
+      add_button_raw(text, response_id)
+    end
+
+    alias_method :get_widget_for_response_raw, :get_widget_for_response
+    def get_widget_for_response(response_id)
+      case response_id
+      when Symbol
+        response_id = ResponseType.new(response_id)
+      end
+      get_widget_for_response_raw(response_id)
+    end
+
+    if method_defined?(:use_header_bar)
+      alias_method :use_header_bar_raw, :use_header_bar
+      undef_method :use_header_bar
+      def use_header_bar?
+        use_header_bar_raw != 0
+      end
+    end
+  end
+end

--- a/gtk4/lib/gtk4/entry-buffer.rb
+++ b/gtk4/lib/gtk4/entry-buffer.rb
@@ -1,0 +1,28 @@
+# Copyright (C) 2015  Ruby-GNOME2 Project Team
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+
+module Gtk
+  class EntryBuffer
+    alias_method :initialize_raw, :initialize
+    def initialize(text=nil)
+      if text.nil?
+        initialize_raw(nil, -1)
+      else
+        initialize_raw(text, text.size)
+      end
+    end
+  end
+end

--- a/gtk4/lib/gtk4/file-chooser-dialog.rb
+++ b/gtk4/lib/gtk4/file-chooser-dialog.rb
@@ -1,0 +1,36 @@
+# Copyright (C) 2015  Ruby-GNOME2 Project Team
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+
+module Gtk
+  class FileChooserDialog
+    alias_method :initialize_raw, :initialize
+    def initialize(options={})
+      GLib::Object.instance_method(:initialize).bind(self).call
+      Loader.reference_gobject(self, :sink => true)
+
+      title = options[:title]
+      parent = options[:parent]
+      action = options[:action] || :open
+      buttons = options[:buttons]
+
+      set_title(title) if title
+      set_action(action) if action
+      set_transient_for(parent) if parent
+
+      add_buttons(*buttons) if buttons
+    end
+  end
+end

--- a/gtk4/lib/gtk4/font-chooser-dialog.rb
+++ b/gtk4/lib/gtk4/font-chooser-dialog.rb
@@ -1,0 +1,27 @@
+# Copyright (C) 2015  Ruby-GNOME2 Project Team
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+
+module Gtk
+  class FontChooserDialog
+    alias_method :initialize_raw, :initialize
+    def initialize(options={})
+      title = options[:title]
+      parent = options[:parent]
+
+      initialize_raw(title, parent)
+    end
+  end
+end

--- a/gtk4/lib/gtk4/gdk-drag-context.rb
+++ b/gtk4/lib/gtk4/gdk-drag-context.rb
@@ -1,0 +1,29 @@
+# Copyright (C) 2015  Ruby-GNOME2 Project Team
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+
+module Gdk # Not Gtk!
+  class DragContext
+    alias_method :finish_raw, :finish
+    def finish(options={})
+      success = options[:success]
+      success = true if success.nil?
+      delete = options[:delete]
+      delete = false if delete.nil?
+      time = options[:time] || Gdk::CURRENT_TIME
+      finish_raw(success, delete, time)
+    end
+  end
+end

--- a/gtk4/lib/gtk4/gesture-multi-press.rb
+++ b/gtk4/lib/gtk4/gesture-multi-press.rb
@@ -1,0 +1,31 @@
+# Copyright (C) 2015  Ruby-GNOME2 Project Team
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+
+module Gtk
+  if const_defined?(:GestureMultiPress)
+    class GestureMultiPress
+      alias_method :area_raw, :area
+      def area
+        filled, rectangle = area_raw
+        if filled
+          rectangle
+        else
+          nil
+        end
+      end
+    end
+  end
+end

--- a/gtk4/lib/gtk4/icon-size.rb
+++ b/gtk4/lib/gtk4/icon-size.rb
@@ -1,0 +1,32 @@
+# Copyright (C) 2015  Ruby-GNOME2 Project Team
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+
+module Gtk
+  class IconSize
+    class << self
+      alias_method :lookup_raw, :lookup
+      def lookup(size)
+        size = new(size) unless size.is_a?(self)
+        valid, width, height = lookup_raw(size)
+        if valid
+          [width, height]
+        else
+          nil
+        end
+      end
+    end
+  end
+end

--- a/gtk4/lib/gtk4/icon-theme.rb
+++ b/gtk4/lib/gtk4/icon-theme.rb
@@ -1,0 +1,38 @@
+# Copyright (C) 2015  Ruby-GNOME2 Project Team
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+
+module Gtk
+  class IconTheme
+    alias_method :choose_icon_raw, :choose_icon
+    def choose_icon(icon_names, size, flags=nil)
+      icon_names = [icon_names] unless icon_names.is_a?(Array)
+      flags ||= 0
+      choose_icon_raw(icon_names, size, flags)
+    end
+
+    alias_method :lookup_icon_raw, :lookup_icon
+    def lookup_icon(icon, size, flags=nil)
+      case icon
+      when String, Symbol
+        flags ||= :generic_fallback
+        lookup_icon_raw(icon.to_s, size, flags)
+      else
+        flags ||= 0
+        lookup_by_gicon(icon, size, flags)
+      end
+    end
+  end
+end

--- a/gtk4/lib/gtk4/icon-view.rb
+++ b/gtk4/lib/gtk4/icon-view.rb
@@ -1,0 +1,45 @@
+# Copyright (C) 2015  Ruby-GNOME2 Project Team
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+
+module Gtk
+  class IconView
+    alias_method :initialize_raw, :initialize
+    def initialize(options={})
+      model = options[:model]
+      area  = options[:area]
+
+      if model
+        initialize_new_with_model(model)
+      elsif area
+        initialize_new_with_area(area)
+      else
+        initialize_new
+      end
+    end
+
+    if method_defined?(:get_cell_rect)
+      alias_method :get_cell_rect_raw, :get_cell_rect
+      def get_cell_rect(path, cell=nil)
+        exist, rect = get_cell_rect_raw(path, cell)
+        if exist
+          rect
+        else
+          nil
+        end
+      end
+    end
+  end
+end

--- a/gtk4/lib/gtk4/image-menu-item.rb
+++ b/gtk4/lib/gtk4/image-menu-item.rb
@@ -1,0 +1,37 @@
+# Copyright (C) 2015  Ruby-GNOME2 Project Team
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+
+module Gtk
+  class ImageMenuItem
+    alias_method :initialize_raw, :initialize
+    def initialize(options={})
+      stock = options[:stock] || nil
+      label = options[:label] || nil
+
+      if stock
+        initialize_new_from_stock(stock)
+      elsif label
+        if options[:use_underline]
+          initialize_new_with_mnemonic(label)
+        else
+          initialize_new_with_label(label)
+        end
+      else
+        initialize_raw
+      end
+    end
+  end
+end

--- a/gtk4/lib/gtk4/image.rb
+++ b/gtk4/lib/gtk4/image.rb
@@ -1,0 +1,118 @@
+# Copyright (C) 2014-2015  Ruby-GNOME2 Project Team
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+
+module Gtk
+  class Image
+    alias_method :initialize_raw, :initialize
+    # Creates a Gtk::Image. The source of the image depends on the options
+    # given.
+    #
+    # @param Hash{Symbol => Gtk::Stock, String, Gtk::IconSet, Gio::Icon,
+    #                       GdkPixbuf::Pixbuf, GdkPixbuf::PixbufAnimation, Cairo::Surface,
+    #                       Fixnum}
+    #
+    # @example Create an empty image.
+    #   image = Gtk::Image.new
+    #
+    # @example Create an image from a file.
+    #   image = Gtk::Image.new :file => 'path/to/the/image.png'
+    #
+    # @example Create an image from stock.
+    #   image = Gtk::Image.new :stock => Gtk::Stock::OPEN, :size => :dialog
+    #
+    # @example Create an image from icon name.
+    #   image = Gtk::Image.new :icon_name => 'gtk-open', :size => :dialog
+    #
+    # @example Create an image from a Gio::Icon, that itself is loaded from a
+    #          file.
+    #   icon = Gio::Icon.new_for_string 'path/to/the/image.png'
+    #   image = Gtk::Image.new :icon => icon, :size => :dialog
+    #
+    # @example Create an image from from a Gio::Icon that is an Gio::ThemedIcon.
+    #   icon = Gio::ThemedIcon.new 'gtk-open'
+    #   image = Gtk::Image.new :icon => icon, :size => :dialog
+    #
+    # @example Create an image from a GdkPixbuf::Pixbuf.
+    #   pixbuf = GdkPixbuf::Pixbuf.new(:file => 'path/to/the/image.png')
+    #   image = Gtk::Image.new :pixbuf => pixbuf
+    #
+    # @example Create an image from an Gtk::IconSet, that itself is created
+    #          from a GdkPixbuf::Pixbuf.
+    #   pixbuf = GdkPixbuf::Pixbuf.new(:file => 'path/to/the/image.png')
+    #   iconSet = Gtk::IconSet.new pixbuf
+    #   image = Gtk::Image.new :icon_set => iconSet, :size => :dialog
+    #
+    # @example Create an image from a GdkPixbuf::PixbufAnimation
+    #   pixAnim = GdkPixbuf::PixbufAnimation.new 'anim.gif'
+    #   image = Gtk::Image.new :animation => pixAnim
+    #
+    # @example Create an image from a file in a resource file
+    #   resource = Gio::Resource.load(a_resource_file)
+    #   Gio::Resources.register(resource)
+    #   resource_path = "/path/to/image.png"
+    #   image = Gtk::Image.new :resource => resource_path
+    #
+    # @example Create an image from a Cairo::Surface that is a
+    #          Cairo::ImageSurface.
+    #   surface = Cairo::ImageSurface.new :RGB24, 60, 60
+    #   context = Cairo::Context.new surface
+    #   context.set_source_rgb 0, 1, 0
+    #   context.rectangle 10, 10, 40, 40
+    #   context.fill.stroke
+    #   image = Gtk::Image.new :surface => surface
+    def initialize(options={})
+      stock     = options[:stock] || nil
+      icon_name = options[:icon_name] || nil
+      icon_set  = options[:icon_set] || nil
+      icon      = options[:icon] || options[:gicon] || nil
+      file      = options[:file] || nil
+      pixbuf    = options[:pixbuf] || nil
+      animation = options[:animation] || nil
+      resource  = options[:resource] ||nil
+      surface   = options[:surface] || nil
+      size      = options[:size] || nil
+
+      case size
+      when String, Symbol
+        size = IconSize.new(size)
+      else
+        size ||= IconSize::BUTTON
+      end
+
+      if stock
+        initialize_new_from_stock(stock, size)
+      elsif icon_name
+        initialize_new_from_icon_name(icon_name, size)
+      elsif icon_set
+        initialize_new_from_icon_set(icon_set, size)
+      elsif icon
+        initialize_new_from_gicon(icon, size)
+      elsif file
+        initialize_new_from_file(file)
+      elsif pixbuf
+        initialize_new_from_pixbuf(pixbuf)
+      elsif animation
+        initialize_new_from_animation(animation)
+      elsif resource
+        initialize_new_from_resource(resource)
+      elsif surface
+        initialize_new_from_surface(surface)
+      else
+        initialize_raw
+      end
+    end
+  end
+end

--- a/gtk4/lib/gtk4/label.rb
+++ b/gtk4/lib/gtk4/label.rb
@@ -1,0 +1,54 @@
+# Copyright (C) 2014  Ruby-GNOME2 Project Team
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+
+module Gtk
+  class Label
+    alias_method :initialize_raw, :initialize
+    def initialize(text=nil, options={})
+      if options == true or options == false or options.nil?
+        mnemonic = options
+        warn "Gtk::Label.new(text, mnemonic) style has been deprecated. " +
+             "Use Gtk::Label.new(text, {:use_underline => #{mnemonic}}) style instead."
+        options = {
+          :use_underline => mnemonic,
+        }
+      end
+      if options[:use_underline]
+        initialize_new_with_mnemonic(text)
+      else
+        initialize_raw(text || "")
+      end
+    end
+
+    private :set_markup_with_mnemonic
+    alias_method :set_markup_raw, :set_markup
+    def set_markup(text, options={})
+      if options == true or options == false or options.nil?
+        mnemonic = options
+        warn "Gtk::Label#set_markup(text, mnemonic) style has been deprecated. " +
+             "Use Gtk::Label#set_marup(text, {:use_underline => #{mnemonic}}) style instead."
+        options = {
+          :use_underline => mnemonic,
+        }
+      end
+      if options[:use_underline]
+        set_markup_with_mnemonic(text)
+      else
+        set_markup_raw(text)
+      end
+    end
+  end
+end

--- a/gtk4/lib/gtk4/level-bar.rb
+++ b/gtk4/lib/gtk4/level-bar.rb
@@ -1,0 +1,32 @@
+# Copyright (C) 2014  Ruby-GNOME2 Project Team
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+
+module Gtk
+  class LevelBar
+    if method_defined?(:get_offset_value)
+      alias_method :get_offset_value_raw, :get_offset_value
+
+      def get_offset_value(name)
+        found, offset = get_offset_value_raw(name)
+        if found
+          offset
+        else
+          nil
+        end
+      end
+    end
+  end
+end

--- a/gtk4/lib/gtk4/list-store.rb
+++ b/gtk4/lib/gtk4/list-store.rb
@@ -1,0 +1,63 @@
+# Copyright (C) 2015  Ruby-GNOME2 Project Team
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+
+module Gtk
+  class ListStore
+    alias_method :initialize_raw, :initialize
+    def initialize(*columns)
+      if columns.empty?
+        raise ArgumentError, "No column type is specified"
+      end
+      initialize_raw(columns)
+    end
+
+    alias_method :append_raw, :append
+    def append
+      iter = append_raw
+      setup_iter(iter)
+      iter
+    end
+
+    alias_method :prepend_raw, :prepend
+    def prepend
+      iter = prepend_raw
+      setup_iter(iter)
+      iter
+    end
+
+    alias_method :insert_raw, :insert
+    def insert(index, values=nil)
+      iter = insert_raw(index)
+      setup_iter(iter)
+      set_values(iter, values) if values
+      iter
+    end
+
+    alias_method :insert_before_raw, :insert_before
+    def insert_before(index)
+      iter = insert_before_raw(index)
+      setup_iter(iter)
+      iter
+    end
+
+    alias_method :insert_after_raw, :insert_after
+    def insert_after(index)
+      iter = insert_after_raw(index)
+      setup_iter(iter)
+      iter
+    end
+  end
+end

--- a/gtk4/lib/gtk4/loader.rb
+++ b/gtk4/lib/gtk4/loader.rb
@@ -1,0 +1,82 @@
+# Copyright (C) 2014-2018  Ruby-GNOME2 Project Team
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+
+module Gtk
+  class Loader < GObjectIntrospection::Loader
+    def initialize(base_module, init_arguments)
+      super(base_module)
+      @init_arguments = init_arguments
+    end
+
+    def load
+      self.version = "4.0"
+      super("Gtk")
+    end
+
+    private
+
+    def pre_load(repository, namespace)
+      call_init_function(repository, namespace)
+      define_version_module
+    end
+
+    def call_init_function(repository, namespace)
+      init_check = repository.find(namespace, "init_check")
+      arguments = [
+        [$0] + @init_arguments,
+      ]
+      succeeded, argv = init_check.invoke(arguments)
+      @init_arguments.replace(argv[1..-1]) unless argv.nil?
+      raise InitError, "failed to initialize GTK+" unless succeeded
+    end
+
+    def define_version_module
+      @version_module = Module.new
+      @base_module.const_set("Version", @version_module)
+    end
+
+    def post_load(repository, namespace)
+      require_extension
+      require_libraries
+    end
+
+    def require_extension
+    end
+
+    def require_libraries
+      require "gtk4/version"
+    end
+
+    def load_constant_info(info)
+      case info.name
+      when /_VERSION\z/
+        @version_module.const_set($PREMATCH, info.value)
+      else
+        super
+      end
+    end
+
+    def rubyish_method_name(function_info, options={})
+      name = function_info.name
+      case name
+      when /\Alist_(child_properties|style_properties)\z/
+        $1
+      else
+        super
+      end
+    end
+  end
+end

--- a/gtk4/lib/gtk4/menu-item.rb
+++ b/gtk4/lib/gtk4/menu-item.rb
@@ -1,0 +1,34 @@
+# Copyright (C) 2015  Ruby-GNOME2 Project Team
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+
+module Gtk
+  class MenuItem
+    alias_method :initialize_raw, :initialize
+    def initialize(options={})
+      label = options[:label]
+
+      if label
+        if options[:use_underline]
+          initialize_new_with_mnemonic(label)
+        else
+          initialize_new_with_label(label)
+        end
+      else
+        initialize_raw
+      end
+    end
+  end
+end

--- a/gtk4/lib/gtk4/message-dialog.rb
+++ b/gtk4/lib/gtk4/message-dialog.rb
@@ -1,0 +1,49 @@
+# Copyright (C) 2015  Ruby-GNOME2 Project Team
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+
+module Gtk
+  class MessageDialog
+    def initialize(options={})
+      parent  = options[:parent]
+      flags   = options[:flags] || 0
+      type    = options[:type] || :info
+      buttons = options[:buttons] || options[:buttons_type] || :ok
+      message = options[:message]
+
+      initialize_general = GLib::Object.instance_method(:initialize).bind(self)
+      initialize_general.call(:message_type => type,
+                              :buttons => buttons)
+      Loader.reference_gobject(self, :sink => true)
+
+      if message
+        self.use_markup = false
+        self.text = message
+      end
+
+      if parent
+        self.transient_for = parent
+      end
+
+      if flags
+        unless flags.is_a?(DialogFlags)
+          flags = DialogFlags.new(flags)
+        end
+        self.modal = true if flags.modal?
+        self.destroy_with_parent = true if flags.destroy_with_parent?
+      end
+    end
+  end
+end

--- a/gtk4/lib/gtk4/paned.rb
+++ b/gtk4/lib/gtk4/paned.rb
@@ -1,0 +1,37 @@
+# Copyright (C) 2015  Ruby-GNOME2 Project Team
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+
+module Gtk
+  class Paned
+    alias_method :pack1_raw, :pack1
+    def pack1(child, options={})
+      resize = options[:resize]
+      resize = false if resize.nil?
+      shrink = options[:shrink]
+      shrink = true if shrink.nil?
+      pack1_raw(child, resize, shrink)
+    end
+
+    alias_method :pack2_raw, :pack2
+    def pack2(child, options={})
+      resize = options[:resize]
+      resize = true if resize.nil?
+      shrink = options[:shrink]
+      shrink = true if shrink.nil?
+      pack2_raw(child, resize, shrink)
+    end
+  end
+end

--- a/gtk4/lib/gtk4/radio-action.rb
+++ b/gtk4/lib/gtk4/radio-action.rb
@@ -1,0 +1,28 @@
+# Copyright (C) 2015  Ruby-GNOME2 Project Team
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+
+module Gtk
+  class RadioAction
+    alias_method :initialize_raw, :initialize
+    def initialize(name, value, options={})
+      initialize_raw(name,
+                     options[:label],
+                     options[:tooltip],
+                     options[:stock_id],
+                     value)
+    end
+  end
+end

--- a/gtk4/lib/gtk4/radio-button.rb
+++ b/gtk4/lib/gtk4/radio-button.rb
@@ -1,0 +1,49 @@
+# Copyright (C) 2015  Ruby-GNOME2 Project Team
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+
+module Gtk
+  class RadioButton
+    alias_method :initialize_raw, :initialize
+    def initialize(options={})
+      group         = options[:group]
+      label         = options[:label]
+      member        = options[:member]
+      use_underline = options[:use_underline]
+
+      if label
+        if member
+          if use_underline
+            initialize_new_with_mnemonic_from_widget(member, label)
+          else
+            initialize_new_with_label_from_widget(member, label)
+          end
+        else
+          if use_underline
+            initialize_new_with_mnemonic(group, label)
+          else
+            initialize_new_with_label(group, label)
+          end
+        end
+      else
+        if member
+          initialize_new_from_widget(member)
+        else
+          initialize_raw
+        end
+      end
+    end
+  end
+end

--- a/gtk4/lib/gtk4/recent-chooser-dialog.rb
+++ b/gtk4/lib/gtk4/recent-chooser-dialog.rb
@@ -1,0 +1,38 @@
+# Copyright (C) 2015  Ruby-GNOME2 Project Team
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+
+module Gtk
+  class RecentChooserDialog
+    alias_method :initialize_raw, :initialize
+    def initialize(options={})
+      initialize_options = {
+        :recent_manager => options[:recent_manager],
+      }
+      gobject_initialize = GLib::Object.instance_method(:initialize).bind(self)
+      gobject_initialize.call(initialize_options)
+      Loader.reference_gobject(self, :sink => true)
+
+      title = options[:title]
+      parent = options[:parent]
+      buttons = options[:buttons]
+
+      set_title(title) if title
+      set_transient_for(parent) if parent
+
+      add_buttons(*buttons) if buttons
+    end
+  end
+end

--- a/gtk4/lib/gtk4/scale-button.rb
+++ b/gtk4/lib/gtk4/scale-button.rb
@@ -1,0 +1,35 @@
+# Copyright (C) 2015  Ruby-GNOME2 Project Team
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+
+module Gtk
+  class ScaleButton
+    alias_method :initialize_raw, :initialize
+    def initialize(options={})
+      icon_size = options[:icon_size] || :button
+      min       = options[:min]       || 0
+      max       = options[:max]       || 100
+      step      = options[:step]      || 2
+      icons     = options[:icons]     || nil
+
+      case icon_size
+      when Symbol, String
+        icon_size = IconSize.new(icon_size.to_s)
+      end
+
+      initialize_raw(icon_size, min, max, step, icons)
+    end
+  end
+end

--- a/gtk4/lib/gtk4/scrolled-window.rb
+++ b/gtk4/lib/gtk4/scrolled-window.rb
@@ -1,0 +1,24 @@
+# Copyright (C) 2014  Ruby-GNOME2 Project Team
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+
+module Gtk
+  class ScrolledWindow
+    alias_method :initialize_raw, :initialize
+    def initialize(hadjustment=nil, vadjustment=nil)
+      initialize_raw(hadjustment, vadjustment)
+    end
+  end
+end

--- a/gtk4/lib/gtk4/search-bar.rb
+++ b/gtk4/lib/gtk4/search-bar.rb
@@ -1,0 +1,27 @@
+# Copyright (C) 2014  Ruby-GNOME2 Project Team
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+
+module Gtk
+  class SearchBar
+    if method_defined?(:connect_entry)
+      alias_method :connect_entry_raw, :connect_entry
+      def connect_entry(entry)
+        connect_entry_raw(entry)
+        self
+      end
+    end
+  end
+end

--- a/gtk4/lib/gtk4/selection-data.rb
+++ b/gtk4/lib/gtk4/selection-data.rb
@@ -1,0 +1,42 @@
+# Copyright (C) 2015  Ruby-GNOME2 Project Team
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+
+module Gtk
+  class SelectionData
+    alias_method :set_raw, :set
+    def set(type, data, options={})
+      format ||= options[:format]
+      if format.nil?
+        case type
+        when Gdk::Selection::TYPE_INTEGER
+          format = 32
+        when Gdk::Selection::TYPE_STRING
+          format = 8
+        else
+          message = "specify :format as the number of bits of each data"
+          raise ArgumentError, message
+        end
+      end
+      set_raw(type, format, data)
+    end
+
+    alias_method :set_text_raw, :set_text
+    def set_text(text)
+      set_text_raw(text, text.bytesize)
+    end
+    alias_method :text=, :set_text
+  end
+end

--- a/gtk4/lib/gtk4/show-uri.rb
+++ b/gtk4/lib/gtk4/show-uri.rb
@@ -1,0 +1,34 @@
+# Copyright (C) 2015  Ruby-GNOME2 Project Team
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+
+module Gtk
+  class << self
+    alias_method :show_uri_raw, :show_uri
+    def show_uri(uri_or_options)
+      if uri_or_options.is_a?(String)
+        options = {:uri => uri_or_options}
+      else
+        options = uri_or_options
+      end
+
+      screen    = options[:screen]
+      uri       = options[:uri]
+      timestamp = options[:timestamp] || Gdk::CURRENT_TIME
+
+      show_uri_raw(screen, uri, timestamp)
+    end
+  end
+end

--- a/gtk4/lib/gtk4/spin-button.rb
+++ b/gtk4/lib/gtk4/spin-button.rb
@@ -1,0 +1,34 @@
+# Copyright (C) 2014  Ruby-GNOME2 Project Team
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+
+module Gtk
+  class SpinButton
+    alias_method :initialize_raw, :initialize
+    def initialize(arg0, arg1=nil, arg2=nil)
+      if arg0.is_a?(Adjustment)
+        adjustment = arg0
+        climb_rate = arg1 || 0.0
+        digits     = arg2 || 0
+        initialize_raw(adjustment, climb_rate, digits)
+      else
+        min  = arg0
+        max  = arg1
+        step = arg2
+        initialize_new_with_range(min, max, step)
+      end
+    end
+  end
+end

--- a/gtk4/lib/gtk4/stack.rb
+++ b/gtk4/lib/gtk4/stack.rb
@@ -1,0 +1,54 @@
+# Copyright (C) 2014  Ruby-GNOME2 Project Team
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+
+module Gtk
+  class Stack
+    if method_defined?(:set_visible_child)
+      alias_method :set_visible_child_raw, :set_visible_child
+      def set_visible_child(widget_or_name, transition_type=nil)
+        case widget_or_name
+        when String
+          name = widget_or_name
+        else
+          widget = widget_or_name
+        end
+
+        if widget
+          set_visible_child_raw(widget)
+        else
+          if transition_type
+            set_visible_child_full(name, transition_type)
+          else
+            set_visible_child_name(name)
+          end
+        end
+      end
+    end
+
+    if method_defined?(:add_titled) and method_defined?(:add_named)
+      def add(widget, name=nil, title=nil)
+        if title
+          add_titled(widget, name, title)
+        elsif name
+          add_named(widget, name)
+        else
+          super(widget)
+        end
+        self
+      end
+    end
+  end
+end

--- a/gtk4/lib/gtk4/stock-item.rb
+++ b/gtk4/lib/gtk4/stock-item.rb
@@ -1,0 +1,36 @@
+# Copyright (C) 2015  Ruby-GNOME2 Project Team
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+
+module Gtk
+  class StockItem
+    def [](*args)
+      warn("#{self.class}\##{__method__} is deprecated. " +
+           "Use \#stock_id, \#label, \#modifier, \#keyval and " +
+           "\#translation_domain instead.")
+      to_a[*args]
+    end
+
+    def to_a
+      [
+        stock_id,
+        label,
+        modifier,
+        keyval,
+        translation_domain,
+      ]
+    end
+  end
+end

--- a/gtk4/lib/gtk4/stock.rb
+++ b/gtk4/lib/gtk4/stock.rb
@@ -1,0 +1,70 @@
+# Copyright (C) 2015  Ruby-GNOME2 Project Team
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+
+module Gtk
+  module Stock
+    class << self
+      alias_method :add_raw, :add
+      def add(stock_id, label, *rest)
+        case rest.size
+        when 0
+          options = {}
+        when 1
+          if rest[0].is_a?(Hash)
+            options = rest[0]
+          else
+            options = {:modifier => rest[0]}
+          end
+        else
+          options = {
+            :modifier           => rest[0],
+            :key_value          => rest[1],
+            :translation_domain => rest[2],
+          }
+        end
+
+        item = StockItem.new
+
+        stock_id = stock_id.to_s if stock_id.is_a?(Symbol)
+        item.stock_id = stock_id
+
+        item.label = label
+
+        modifier = options[:modifier]
+        item.modifier = modifier if modifier
+
+        key_value = options[:key_value]
+        item.keyval = key_value if key_value
+
+        translation_domain = options[:translation_domain]
+        item.translation_domain = translation_domain if translation_domain
+
+        add_raw([item])
+      end
+
+      alias_method :lookup_raw, :lookup
+      def lookup(stock_id)
+        stock_id = stock_id.to_s if stock_id.is_a?(Symbol)
+        found, item = lookup_raw(stock_id)
+        if found
+          item
+        else
+          nil
+        end
+      end
+    end
+  end
+end

--- a/gtk4/lib/gtk4/style-context.rb
+++ b/gtk4/lib/gtk4/style-context.rb
@@ -1,0 +1,26 @@
+# Copyright (C) 2015  Ruby-GNOME2 Project Team
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+
+module Gtk
+  class StyleContext
+    class << self
+      alias_method :reset_widgets_raw, :reset_widgets
+      def reset_widgets(screen=nil)
+        reset_widgets_raw(screen || Gdk::Screen.default)
+      end
+    end
+  end
+end

--- a/gtk4/lib/gtk4/style-properties.rb
+++ b/gtk4/lib/gtk4/style-properties.rb
@@ -1,0 +1,29 @@
+# Copyright (C) 2015  Ruby-GNOME2 Project Team
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+
+module Gtk
+  class StyleProperties
+    alias_method :get_property_raw, :get_property
+    def get_property(key, state)
+      found, property = get_property_raw(key, state)
+      if found
+        property.value
+      else
+        nil
+      end
+    end
+  end
+end

--- a/gtk4/lib/gtk4/table.rb
+++ b/gtk4/lib/gtk4/table.rb
@@ -1,0 +1,43 @@
+# Copyright (C) 2015  Ruby-GNOME2 Project Team
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+
+module Gtk
+  class Table
+    alias_method :initialize_raw, :initialize
+    def initialize(n_rows, n_columns, homogeneous=false)
+      initialize_raw(n_rows, n_columns, homogeneous)
+    end
+
+    alias_method :default_column_spacing, :default_col_spacing
+
+    def column_spacings(column)
+      get_col_spacings(column)
+    end
+    alias_method :set_column_spacings, :set_col_spacings
+    alias_method :column_spacings=,    :col_spacings=
+
+    alias_method :attach_raw, :attach
+    def attach(child, left, right, top, bottom,
+               x_options=nil, y_options=nil,
+               x_space=nil, y_space=nil)
+      attach_raw(child, left, right, top, bottom,
+                 x_options || [:expand, :fill],
+                 y_options || [:expand, :fill],
+                 x_space || 0,
+                 y_space || 0)
+    end
+  end
+end

--- a/gtk4/lib/gtk4/target-entry.rb
+++ b/gtk4/lib/gtk4/target-entry.rb
@@ -1,0 +1,27 @@
+# Copyright (C) 2015  Ruby-GNOME2 Project Team
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+
+module Gtk
+  class TargetEntry
+    alias_method :initialize_raw, :initialize
+    def initialize(target, flags, info)
+      unless flags.is_a?(TargetFlags)
+        flags = TargetFlags.new(flags)
+      end
+      initialize_raw(target, flags.to_i, info)
+    end
+  end
+end

--- a/gtk4/lib/gtk4/target-list.rb
+++ b/gtk4/lib/gtk4/target-list.rb
@@ -1,0 +1,31 @@
+# Copyright (C) 2015  Ruby-GNOME2 Project Team
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+
+module Gtk
+  class TargetList
+    alias_method :find_raw, :find
+    def find(target)
+      target = Gdk::Atom.intern(target) if target.is_a?(String)
+
+      found, info = find_raw(target)
+      if found
+        info
+      else
+        nil
+      end
+    end
+  end
+end

--- a/gtk4/lib/gtk4/text-buffer.rb
+++ b/gtk4/lib/gtk4/text-buffer.rb
@@ -1,0 +1,237 @@
+# Copyright (C) 2014-2017  Ruby-GNOME2 Project Team
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+
+module Gtk
+  class TextBuffer
+    def create_tag(tag_name=nil, properties={})
+      tag = TextTag.new(tag_name)
+      succeeded = tag_table.add(tag)
+      return nil unless succeeded
+
+      properties.each do |name, value|
+        tag.__send__("#{name}=", value)
+      end
+
+      tag
+    end
+
+    alias_method :add_mark_raw, :add_mark
+    def add_mark(mark, where)
+      @marks ||= {}
+      add_mark_raw(mark, where)
+      mark_name = mark.name
+      @marks[mark_name] = mark if mark_name
+    end
+
+    alias_method :create_mark_raw, :create_mark
+    def create_mark(name, where, options={})
+      if options == true or options == false
+        options = {:left_gravity => options}
+      end
+      left_gravity = options[:left_gravity]
+      left_gravity = true if left_gravity.nil?
+      @marks ||= {}
+      if name.nil?
+        create_mark_raw(name, where, left_gravity)
+      else
+        @marks[name] = create_mark_raw(name, where, left_gravity)
+      end
+    end
+
+    alias_method :delete_mark_raw, :delete_mark
+    def delete_mark(mark)
+      @marks ||= {}
+      mark_name = mark.name
+      delete_mark_raw(mark)
+      @marks.delete(mark_name) if mark_name
+    end
+
+    # prevent collision with deprecated methods.
+    alias_method :get_iter_at_line_offset_raw,  :get_iter_at_line_offset
+    alias_method :get_iter_at_line_index_raw,   :get_iter_at_line_index
+    alias_method :get_iter_at_line_raw,         :get_iter_at_line
+    alias_method :get_iter_at_offset_raw,       :get_iter_at_offset
+    alias_method :get_iter_at_mark_raw,         :get_iter_at_mark
+    alias_method :get_iter_at_child_anchor_raw, :get_iter_at_child_anchor
+    def get_iter_at(arguments)
+      line   = arguments[:line]
+      offset = arguments[:offset]
+      index  = arguments[:index]
+      mark   = arguments[:mark]
+      anchor = arguments[:anchor]
+      if line
+        if offset
+          get_iter_at_line_offset_raw(line, offset)
+        elsif index
+          get_iter_at_line_index_raw(line, index)
+        else
+          get_iter_at_line_raw(line)
+        end
+      elsif offset
+        get_iter_at_offset_raw(offset)
+      elsif mark
+        get_iter_at_mark_raw(mark)
+      elsif anchor
+        get_iter_at_child_anchor_raw(anchor)
+      else
+        message =
+          "Must specify one of :line, :offset, :mark or :anchor: #{arguments.inspect}"
+        raise ArgumentError, message
+      end
+    end
+
+    alias_method :insert_raw,              :insert
+    alias_method :insert_pixbuf_raw,       :insert_pixbuf
+    alias_method :insert_child_anchor_raw, :insert_child_anchor
+    def insert(iter, target, *args)
+      options = nil
+      tags = nil
+      case args.size
+      when 0
+        options = {}
+      when 1
+        case args.first
+        when Hash
+          options = args.first
+        else
+          tags = args
+        end
+      else
+        tags = args
+      end
+      if options.nil?
+        signature_prefix = "#{self.class}\##{__method__}(iter, target"
+        warn("#{signature_prefix}, *tags) style has been deprecated. " +
+             "Use #{signature_prefix}, options={:tags => tags}) style instead.")
+        options = {:tags => tags}
+      end
+
+      interactive = options[:interactive]
+      default_editable = options[:default_editable]
+      tags = options[:tags]
+
+      start_offset = iter.offset
+      if interactive
+        default_editable = true if default_editable.nil?
+        insert_interactive(iter, target, default_editable)
+      else
+        case target
+        when GdkPixbuf::Pixbuf
+          insert_pixbuf_raw(iter, target)
+        when TextChildAnchor
+          insert_text_child_anchor_raw(iter, target)
+        when GLib::Bytes
+          insert_raw(iter, target, target.size)
+        else
+          insert_raw(iter, target, target.bytesize)
+        end
+      end
+
+      if tags
+        start_iter = get_iter_at(:offset => start_offset)
+        tags.each do |tag|
+          tag = tag_table.lookup(tag) if tag.is_a?(String)
+          apply_tag(tag, start_iter, iter)
+        end
+      end
+
+      self
+    end
+
+    if method_defined?(:insert_markup)
+      alias_method :insert_markup_raw, :insert_markup
+      def insert_markup(iter, markup, n_bytes=nil)
+        case markup
+        when GLib::Bytes
+          n_bytes ||= markup.size
+        else
+          n_bytes ||= markup.bytesize
+        end
+        insert_markup_raw(iter, markup, n_bytes)
+      end
+    end
+
+    alias_method :insert_at_cursor_raw, :insert_at_cursor
+    def insert_at_cursor(text, options={})
+      interactive = options[:interactive]
+      default_editable = options[:default_editable]
+
+      if interactive
+        default_editable = true if default_editable.nil?
+        insert_interactive_at_cursor(text, default_editable)
+      else
+        insert_at_cursor_raw(text, text.bytesize)
+      end
+    end
+
+    alias_method :set_text_raw, :set_text
+    def set_text(text)
+      if text.is_a?(GLib::Bytes)
+        text, text_size = text.to_s, text.size
+      else
+        text_size = text.bytesize
+      end
+      set_text_raw(text, text_size)
+    end
+    remove_method :text=
+    alias_method :text=, :set_text
+
+    alias_method :apply_tag_raw, :apply_tag
+    def apply_tag(tag, start, last)
+      if tag.is_a?(String)
+        apply_tag_by_name(tag, start, last)
+      else
+        apply_tag_raw(tag, start, last)
+      end
+    end
+
+    alias_method :serialize_raw, :serialize
+    def serialize(*arguments)
+      serialize_raw(*arguments).pack("C*")
+    end
+
+    alias_method :selection_bounds_raw, :selection_bounds
+    def selection_bounds
+      selected, start_iter, end_iter = selection_bounds_raw
+      if selected
+        [start_iter, end_iter]
+      else
+        nil
+      end
+    end
+
+    private
+    alias_method :insert_interactive_raw, :insert_interactive
+    def insert_interactive(iter, text, default_ediatable)
+      if text.is_a?(GLib::Bytes)
+        text, text_size = text.to_s, text.size
+      else
+        text_size = text.bytesize
+      end
+      insert_interactive_raw(iter, text, text_size, default_ediatable)
+    end
+
+    alias_method :insert_interactive_at_cursor_raw, :insert_interactive_at_cursor
+    def insert_interactive_at_cursor(text, default_ediatable)
+      if text.is_a?(GLib::Bytes)
+        text, text_size = text.to_s, text.size
+      else
+        text_size = text.bytesize
+      end
+      insert_interactive_at_cursor_raw(text, text_size, default_ediatable)
+    end
+  end
+end

--- a/gtk4/lib/gtk4/text-iter.rb
+++ b/gtk4/lib/gtk4/text-iter.rb
@@ -1,0 +1,39 @@
+# Copyright (C) 2015  Ruby-GNOME2 Project Team
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+
+module Gtk
+  class TextIter
+    alias_method :forward_search_raw, :forward_search
+    def forward_search(text, flags, limit=nil)
+      found, start_iter, end_iter = forward_search_raw(text, flags, limit)
+      if found
+        [start_iter, end_iter]
+      else
+        nil
+      end
+    end
+
+    alias_method :backward_search_raw, :backward_search
+    def backward_search(text, flags, limit=nil)
+      found, start_iter, end_iter = backward_search_raw(text, flags, limit)
+      if found
+        [start_iter, end_iter]
+      else
+        nil
+      end
+    end
+  end
+end

--- a/gtk4/lib/gtk4/text-tag-table.rb
+++ b/gtk4/lib/gtk4/text-tag-table.rb
@@ -1,0 +1,31 @@
+# Copyright (C) 2015  Ruby-GNOME2 Project Team
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+
+module Gtk
+  class TextTagTable
+    alias_method :add_raw, :add
+    def add(tag)
+      succeeded = add_raw(tag)
+      # GTK+ 3.12 or older returns nothing.
+      # We assume that it's always succeeded for the case.
+      if succeeded.nil?
+        true
+      else
+        succeeded
+      end
+    end
+  end
+end

--- a/gtk4/lib/gtk4/text-tag.rb
+++ b/gtk4/lib/gtk4/text-tag.rb
@@ -1,0 +1,41 @@
+# Copyright (C) 2017  Ruby-GNOME2 Project Team
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+
+module Gtk
+  class TextTag
+    alias_method :set_weight_raw, :set_weight
+    def set_weight(weight)
+      case weight
+      when Symbol, String
+        weight = Pango::Weight.new(weight).to_i
+      end
+      set_weight_raw(weight)
+    end
+    undef_method :weight=
+    alias_method :weight=, :set_weight
+
+    alias_method :set_scale_raw, :set_scale
+    def set_scale(scale)
+      case scale
+      when Symbol, String
+        scale = Pango::Scale.const_get(scale.to_s.upcase)
+      end
+      set_scale_raw(scale)
+    end
+    undef_method :scale=
+    alias_method :scale=, :set_scale
+  end
+end

--- a/gtk4/lib/gtk4/text-view.rb
+++ b/gtk4/lib/gtk4/text-view.rb
@@ -1,0 +1,64 @@
+# Copyright (C) 2016-2017  Ruby-GNOME2 Project Team
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+
+module Gtk
+  class TextView
+    def get_iter_at(options)
+      location = options[:location]
+      position = options[:position]
+
+      if location
+        get_iter_at_location(*location)
+      elsif position
+        get_iter_at_position(*position)
+      else
+        message = "must specify :location or :position: #{options.inspect}"
+        raise ArgumentError, message
+      end
+    end
+
+    alias_method :get_iter_at_location_raw, :get_iter_at_location
+    def get_iter_at_location(x, y)
+      result = get_iter_at_location_raw(x, y)
+      if result.is_a?(Gtk::TextIter) # For GTK+ < 3.20
+        iter = result
+        iter
+      else
+        found, iter = result
+        if found
+          iter
+        else
+          nil
+        end
+      end
+    end
+
+    alias_method :get_iter_at_position_raw, :get_iter_at_position
+    def get_iter_at_position(x, y)
+      result = get_iter_at_position_raw(x, y)
+      if result.size == 2 # For GTK+ < 3.20
+        result
+      else
+        found, iter, trailing = result
+        if found
+          [iter, trailing]
+        else
+          nil
+        end
+      end
+    end
+  end
+end

--- a/gtk4/lib/gtk4/toggle-action.rb
+++ b/gtk4/lib/gtk4/toggle-action.rb
@@ -1,0 +1,27 @@
+# Copyright (C) 2015  Ruby-GNOME2 Project Team
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+
+module Gtk
+  class ToggleAction
+    alias_method :initialize_raw, :initialize
+    def initialize(name, options={})
+      initialize_raw(name,
+                     options[:label],
+                     options[:tooltip],
+                     options[:stock_id])
+    end
+  end
+end

--- a/gtk4/lib/gtk4/toggle-button.rb
+++ b/gtk4/lib/gtk4/toggle-button.rb
@@ -1,0 +1,35 @@
+# Copyright (C) 2015  Ruby-GNOME2 Project Team
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+
+module Gtk
+  class ToggleButton
+    alias_method :initialize_raw, :initialize
+    def initialize(options={})
+      label = options[:label]
+      use_underline = options[:use_underline]
+
+      if label
+        if use_underline
+          initialize_new_with_mnemonic(label)
+        else
+          initialize_new_with_label(label)
+        end
+      else
+        initialize_raw
+      end
+    end
+  end
+end

--- a/gtk4/lib/gtk4/tool-button.rb
+++ b/gtk4/lib/gtk4/tool-button.rb
@@ -1,0 +1,36 @@
+# Copyright (C) 2015  Ruby-GNOME2 Project Team
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+
+module Gtk
+  class ToolButton
+    alias_method :initialize_raw, :initialize
+    def initialize(options={})
+      icon_widget = options[:icon_widget]
+      label       = options[:label]
+      stock_id    = options[:stock_id]
+
+      if icon_widget
+        initialize_new(icon_widget)
+      elsif stock_id
+        initialize_new_from_stock(stock_id)
+      else
+        initialize_new
+      end
+
+      set_label(label) if label
+    end
+  end
+end

--- a/gtk4/lib/gtk4/tree-iter.rb
+++ b/gtk4/lib/gtk4/tree-iter.rb
@@ -1,0 +1,86 @@
+# Copyright (C) 2014-2016 Ruby-GNOME2 Project Team
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+
+module Gtk
+  class TreeIter
+    def model
+      @model
+    end
+
+    def model=(model)
+      @model = model
+    end
+
+    def get_value(column)
+      @model.get_value(self, column)
+    end
+    alias_method :[], :get_value
+
+    def set_value(column, value)
+      gtype = @model.get_column_type(column)
+      gvalue = GLib::Value.new(gtype, value)
+      @model.set_value(self, column, gvalue)
+    end
+    alias_method :[]=, :set_value
+
+    def set_values(values)
+      @model.set_values(self, values)
+    end
+    alias_method :values=, :set_values
+
+    def path
+      @model.get_path(self)
+    end
+
+    def previous!
+      @model.iter_previous(self)
+    end
+
+    def next!
+      @model.iter_next(self)
+    end
+
+    def parent
+      @model.iter_parent(self)
+    end
+
+    def has_child?
+      @model.iter_has_child(self)
+    end
+
+    def n_children
+      @model.iter_n_children(self)
+    end
+
+    def nth_child(n)
+      @model.iter_nth_child(self, n)
+    end
+
+    def children
+      @model.iter_children(self)
+    end
+
+    def first_child
+      nth_child(0)
+    end
+
+    def ==(other)
+      other.is_a?(self.class) and
+        @model == other.model and
+        path == other.path
+    end
+  end
+end

--- a/gtk4/lib/gtk4/tree-model-filter.rb
+++ b/gtk4/lib/gtk4/tree-model-filter.rb
@@ -1,0 +1,45 @@
+# Copyright (C) 2015  Ruby-GNOME2 Project Team
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+
+module Gtk
+  class TreeModelFilter
+    def initialize(child_model, root=nil)
+      super(:child_model => child_model, :virtual_root => root)
+    end
+
+    alias_method :set_modify_func_raw, :set_modify_func
+    def set_modify_func(*types, &block)
+      raise ArgumentError, "one or more types are required" if types.empty?
+      set_modify_func_raw(types, &block)
+    end
+
+    alias_method :convert_iter_to_child_iter_raw, :convert_iter_to_child_iter
+    def convert_iter_to_child_iter(iter)
+      child_iter = convert_iter_to_child_iter_raw(iter)
+      child_iter.model = model
+      child_iter
+    end
+
+    alias_method :convert_child_iter_to_iter_raw, :convert_child_iter_to_iter
+    def convert_child_iter_to_iter(child_iter)
+      converted, iter = convert_child_iter_to_iter_raw(child_iter)
+      return nil unless converted
+
+      iter.model = self
+      iter
+    end
+  end
+end

--- a/gtk4/lib/gtk4/tree-model.rb
+++ b/gtk4/lib/gtk4/tree-model.rb
@@ -1,0 +1,115 @@
+# Copyright (C) 2014-2015  Ruby-GNOME2 Project Team
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+
+module Gtk
+  module TreeModel
+    alias_method :get_iter_raw, :get_iter
+    def get_iter(path)
+      if path.is_a?(String)
+        got, iter = get_iter_from_string(path)
+      else
+        got, iter = get_iter_raw(path)
+      end
+
+      if got
+        setup_iter(iter)
+        iter
+      else
+        nil
+      end
+    end
+
+    alias_method :iter_first_raw, :iter_first
+    def iter_first
+      got, iter = iter_first_raw
+      if got
+        setup_iter(iter)
+        iter
+      else
+        nil
+      end
+    end
+
+    alias_method :iter_parent_raw, :iter_parent
+    def iter_parent(iter)
+      got, iter = iter_parent_raw(iter)
+      if got
+        setup_iter(iter)
+        iter
+      else
+        nil
+      end
+    end
+
+    alias_method :get_value_raw, :get_value
+    def get_value(iter, column)
+      get_value_raw(iter, column).value
+    end
+
+    alias_method :iter_nth_child_raw, :iter_nth_child
+    def iter_nth_child(iter, n)
+      got, iter = iter_nth_child_raw(iter, n)
+      if got
+        setup_iter(iter)
+        iter
+      else
+        nil
+      end
+    end
+
+    alias_method :iter_children_raw, :iter_children
+    def iter_children(iter)
+      got, iter = iter_children_raw(iter)
+      if got
+        setup_iter(iter)
+        iter
+      else
+        nil
+      end
+    end
+
+    def set_values(iter, values)
+      columns = []
+      _values = []
+      if values.is_a?(Hash)
+        values.each do |column_id, value|
+          type = get_column_type(column_id)
+          columns << column_id
+          _values << GLib::Value.new(type, value)
+        end
+      else
+        values.each_with_index do |value, i|
+          type = get_column_type(i)
+          columns << i
+          _values << GLib::Value.new(type, value)
+        end
+      end
+      set(iter, columns, _values)
+    end
+
+    alias_method :get_column_type_raw, :get_column_type
+    def get_column_type(index)
+      (@column_types ||= {})[index] ||= get_column_type_raw(index)
+    end
+
+    alias_method :create_filter, :filter_new
+
+    private
+    def setup_iter(iter)
+      iter.model = self
+    end
+  end
+end

--- a/gtk4/lib/gtk4/tree-path.rb
+++ b/gtk4/lib/gtk4/tree-path.rb
@@ -1,0 +1,29 @@
+# Copyright (C) 2015  Ruby-GNOME2 Project Team
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+
+module Gtk
+  class TreePath
+    include Comparable
+
+    def <=>(other)
+      if other.is_a?(self.class)
+        compare(other)
+      else
+        nil
+      end
+    end
+  end
+end

--- a/gtk4/lib/gtk4/tree-selection.rb
+++ b/gtk4/lib/gtk4/tree-selection.rb
@@ -1,0 +1,28 @@
+# Copyright (C) 2014-2015  Ruby-GNOME2 Project Team
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+
+module Gtk
+  class TreeSelection
+    alias_method :selected_raw, :selected
+    def selected
+      selected_p, model, iter = selected_raw
+      return nil unless selected_p
+
+      iter.model = model
+      iter
+    end
+  end
+end

--- a/gtk4/lib/gtk4/tree-store.rb
+++ b/gtk4/lib/gtk4/tree-store.rb
@@ -1,0 +1,60 @@
+# Copyright (C) 2014  Ruby-GNOME2 Project Team
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+
+module Gtk
+  class TreeStore
+    alias_method :initialize_raw, :initialize
+    def initialize(*column_types)
+      initialize_raw(column_types)
+    end
+
+    alias_method :insert_raw, :insert
+    def insert(parent, position, values=nil)
+      iter = insert_raw(parent, position)
+      setup_iter(iter)
+      set_values(iter, values) if values
+      iter
+    end
+
+    alias_method :insert_before_raw, :insert_before
+    def insert_before(parent, sibling)
+      iter = insert_before_raw(parent, sibling)
+      setup_iter(iter)
+      iter
+    end
+
+    alias_method :insert_after_raw, :insert_after
+    def insert_after(parent, sibling)
+      iter = insert_after_raw(parent, sibling)
+      setup_iter(iter)
+      iter
+    end
+
+    alias_method :prepend_raw, :prepend
+    def prepend(parent)
+      iter = prepend_raw(parent)
+      setup_iter(iter)
+      iter
+    end
+
+    alias_method :append_raw, :append
+    def append(parent)
+      iter = append_raw(parent)
+      setup_iter(iter)
+      iter
+    end
+  end
+end

--- a/gtk4/lib/gtk4/tree-view-column.rb
+++ b/gtk4/lib/gtk4/tree-view-column.rb
@@ -1,0 +1,61 @@
+# Copyright (C) 2014-2016  Ruby-GNOME2 Project Team
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+
+module Gtk
+  class TreeViewColumn
+    alias_method :initialize_raw, :initialize
+    def initialize(*args)
+      if args.size == 1 and args[0].is_a?(Hash)
+        options = args[0].dup
+        area = options.delete(:area)
+        renderer = options.delete(:renderer)
+        title = options.delete(:title)
+        attributes = options.delete(:attributes)
+        unless options.empty?
+          names = options.keys.inspect
+          available_names = [:area, :renderer, :title, :attributes].inspect
+          message =
+            "unknown option(s): #{names}: available options: #{available_names}"
+          raise ArgumentError, message
+        end
+      else
+        area = nil
+        title, renderer, attributes = args
+      end
+      attributes ||= {}
+
+      if area
+        initialize_new_with_area(area)
+      else
+        initialize_raw
+      end
+
+      set_title(title) if title
+      if renderer
+        pack_start(renderer, true)
+        attributes.each_entry do |key, value|
+          add_attribute(renderer, key, value)
+        end
+      end
+    end
+
+    alias_method :add_attribute_raw, :add_attribute
+    def add_attribute(renderer, key, value)
+      key = key.to_s if key.is_a?(Symbol)
+      add_attribute_raw(renderer, key, value)
+    end
+  end
+end

--- a/gtk4/lib/gtk4/tree-view.rb
+++ b/gtk4/lib/gtk4/tree-view.rb
@@ -1,0 +1,90 @@
+# Copyright (C) 2015  Ruby-GNOME2 Project Team
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+
+module Gtk
+  class TreeView
+    alias_method :get_path_at_pos_raw, :get_path_at_pos
+    def get_path_at_pos(x, y)
+      found, *info = get_path_at_pos_raw(x, y)
+      if found
+        info
+      else
+        nil
+      end
+    end
+
+    alias_method :enable_model_drag_source_raw, :enable_model_drag_source
+    def enable_model_drag_source(flags, targets, actions)
+      targets = ensure_drag_targets(targets)
+      enable_model_drag_source_raw(flags, targets, actions)
+    end
+
+    alias_method :enable_model_drag_dest_raw, :enable_model_drag_dest
+    def enable_model_drag_dest(targets, actions)
+      targets = ensure_drag_targets(targets)
+      enable_model_drag_dest_raw(targets, actions)
+    end
+
+    alias_method :insert_column_raw, :insert_column
+    def insert_column(*args, &block)
+      case args.size
+      when 2
+        column, position = args
+        insert_column_raw(column, position)
+      when 3
+        position, title, cell = args
+        insert_column_with_data_func(position, title, cell, &block)
+      when 4
+        position, title, cell, attributes = args
+        column = TreeViewColumn.new
+        column.sizing = :fixed if fixed_height_mode?
+        column.title = title
+        column.pack_start(cell, true)
+        attributes.each do |name, column_id|
+          column.add_attribute(cell, name, column_id)
+        end
+        insert_column_raw(column, position)
+      else
+        raise ArgumentError, "wrong number of arguments (#{args.size} for 2..4)"
+      end
+    end
+
+    alias_method :expand_row_raw, :expand_row
+    def expand_row(path, options={})
+      if options == true or options == false
+        open_all = options
+      else
+        open_all = options[:open_all]
+        open_all = true if open_all.nil?
+      end
+
+      expand_row_raw(path, open_all)
+    end
+
+    private
+    def create_signal_handler(signal_name, callback)
+      case signal_name
+      when "row-collapsed", "row-expanded"
+        lambda do |tree_view, iter, path, *extra_args|
+          iter.model = tree_view.model
+          callback.call(tree_view, iter, path, *extra_args)
+        end
+      else
+        super
+      end
+    end
+  end
+end

--- a/gtk4/lib/gtk4/ui-manager.rb
+++ b/gtk4/lib/gtk4/ui-manager.rb
@@ -1,0 +1,35 @@
+# Copyright (C) 2015  Ruby-GNOME2 Project Team
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+
+module Gtk
+  class UIManager
+    alias_method :add_ui_raw, :add_ui
+    def add_ui(buffer_or_filename, *args)
+      if args.empty?
+        if buffer_or_filename =~ /<ui>/
+          add_ui_from_string(buffer_or_filename,
+                             buffer_or_filename.length)
+        else
+          add_ui_from_file(buffer_or_filename)
+        end
+      else
+        merge_id = buffer_or_filename
+        path, name, action, type, top, = args
+        add_ui_raw(merge_id, path, name, action, type, top)
+      end
+    end
+  end
+end

--- a/gtk4/lib/gtk4/version.rb
+++ b/gtk4/lib/gtk4/version.rb
@@ -1,0 +1,28 @@
+# Copyright (C) 2014-2018  Ruby-GNOME2 Project Team
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+
+module Gtk
+  module Version
+    STRING = [MAJOR, MINOR, MICRO].join(".")
+
+    class << self
+      def or_later?(major, minor, micro=nil)
+        error_message = Gtk.check_version(major, minor, micro)
+        error_message.nil?
+      end
+    end
+  end
+end

--- a/gtk4/lib/gtk4/widget.rb
+++ b/gtk4/lib/gtk4/widget.rb
@@ -1,0 +1,147 @@
+# Copyright (C) 2015-2016  Ruby-GNOME2 Project Team
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+
+module Gtk
+  class Widget
+    class << self
+      def init
+      end
+
+      def have_template?
+        @have_template ||= false
+      end
+
+      def template_children
+        @template_children ||= []
+      end
+
+      if method_defined?(:set_template)
+        alias_method :set_template_raw, :set_template
+        def set_template(template)
+          resource = template[:resource]
+          data = template[:data]
+          if resource
+            set_template_from_resource(resource)
+          else
+            set_template_raw(data)
+          end
+          @have_template = true
+        end
+
+        def bind_template_child(name, options={})
+          internal_child = options[:internal_child]
+          internal_child = false if internal_child.nil?
+          bind_template_child_full(name, internal_child, 0)
+          template_children << name
+          attr_reader(name)
+        end
+      end
+
+      alias_method :set_connect_func_raw, :set_connect_func
+      def set_connect_func(&block)
+        set_connect_func_raw do |*args|
+          Builder.connect_signal(*args, &block)
+        end
+      end
+    end
+
+    alias_method :events_raw, :events
+    def events
+      Gdk::EventMask.new(events_raw)
+    end
+
+    alias_method :add_events_raw, :add_events
+    def add_events(new_events)
+      unless new_events.is_a?(Gdk::EventMask)
+        new_events = Gdk::EventMask.new(new_events)
+      end
+      add_events_raw(new_events.to_i)
+    end
+
+    alias_method :set_events_raw, :set_events
+    def set_events(new_events)
+      unless new_events.is_a?(Gdk::EventMask)
+        new_events = Gdk::EventMask.new(new_events)
+      end
+      set_events_raw(new_events.to_i)
+    end
+
+    alias_method :events_raw=, :events=
+    alias_method :events=, :set_events
+
+    alias_method :drag_source_set_raw, :drag_source_set
+    def drag_source_set(flags, targets, actions)
+      targets = ensure_drag_targets(targets)
+      drag_source_set_raw(flags, targets, actions)
+    end
+
+    alias_method :drag_dest_set_raw, :drag_dest_set
+    def drag_dest_set(flags, targets, actions)
+      targets = ensure_drag_targets(targets)
+      drag_dest_set_raw(flags, targets, actions)
+    end
+
+    alias_method :style_get_property_raw, :style_get_property
+    def style_get_property(name)
+      property = self.class.find_style_property(name)
+      value = GLib::Value.new(property.value_type)
+      style_get_property_raw(name, value)
+      value.value
+    end
+
+    alias_method :render_icon_pixbuf_raw, :render_icon_pixbuf
+    def render_icon_pixbuf(stock_id, size)
+      size = IconSize.new(size) unless size.is_a?(IconSize)
+      render_icon_pixbuf_raw(stock_id, size)
+    end
+
+    alias_method :translate_coordinates_raw, :translate_coordinates
+    def translate_coordinates(widget, x, y)
+      translated, x, y = translate_coordinates_raw(widget, x, y)
+      if translated
+        [x, y]
+      else
+        nil
+      end
+    end
+
+    private
+    def initialize_post
+      klass = self.class
+      return unless klass.have_template?
+      return unless respond_to?(:init_template)
+
+      init_template
+      gtype = klass.gtype
+      klass.template_children.each do |name|
+        instance_variable_set("@#{name}", get_template_child(gtype, name))
+      end
+    end
+
+    def ensure_drag_targets(targets)
+      return targets unless targets.is_a?(Array)
+
+      targets.collect do |target|
+        case target
+        when Array
+          TargetEntry.new(*target)
+        else
+          target
+        end
+      end
+    end
+  end
+end

--- a/gtk4/lib/gtk4/window.rb
+++ b/gtk4/lib/gtk4/window.rb
@@ -1,0 +1,42 @@
+# Copyright (C) 2014  Ruby-GNOME2 Project Team
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+
+module Gtk
+  class Window
+    alias_method :initialize_raw, :initialize
+    def initialize(type=:toplevel)
+      if type.is_a?(String)
+        initialize_raw(:toplevel)
+        self.title = type
+      else
+        initialize_raw(type)
+      end
+    end
+
+    alias_method :set_icon_raw, :set_icon
+    def set_icon(icon_or_file_name)
+      case icon_or_file_name
+      when String
+        set_icon_from_file(icon_or_file_name)
+      else
+        set_icon_raw(icon_or_file_name)
+      end
+    end
+
+    remove_method :icon=
+    alias_method :icon=, :set_icon
+  end
+end

--- a/gtk4/test/gtk-test-utils.rb
+++ b/gtk4/test/gtk-test-utils.rb
@@ -1,0 +1,36 @@
+# Copyright (C) 2011-2018  Ruby-GNOME2 Project Team
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+
+require "tempfile"
+require "fileutils"
+
+module GtkTestUtils
+  private
+  def only_gtk_version(major, minor, micro=nil)
+    micro ||= 0
+    unless Gtk::Version.or_later?(major, minor, micro)
+      omit("Require GTK+ >= #{major}.#{minor}.#{micro}")
+    end
+  end
+
+  def window_system_type_name
+    Gdk::Screen.default.class.gtype.name
+  end
+
+  def fixture_path(*components)
+    File.join(File.dirname(__FILE__), "fixture", *components)
+  end
+end

--- a/gtk4/test/run-test.rb
+++ b/gtk4/test/run-test.rb
@@ -1,0 +1,66 @@
+#!/usr/bin/env ruby
+#
+# Copyright (C) 2013-2018  Ruby-GNOME2 Project Team
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+
+ruby_gnome2_base = File.join(File.dirname(__FILE__), "..", "..")
+ruby_gnome2_base = File.expand_path(ruby_gnome2_base)
+
+glib_base = File.join(ruby_gnome2_base, "glib2")
+gobject_introspection_base = File.join(ruby_gnome2_base, "gobject-introspection")
+atk_base = File.join(ruby_gnome2_base, "atk")
+cairo_gobject_base = File.join(ruby_gnome2_base, "cairo-gobject")
+pango_base = File.join(ruby_gnome2_base, "pango")
+gdk_pixbuf_base = File.join(ruby_gnome2_base, "gdk_pixbuf2")
+gio2_base = File.join(ruby_gnome2_base, "gio2")
+gdk4_base = File.join(ruby_gnome2_base, "gdk4")
+gtk4_base = File.join(ruby_gnome2_base, "gtk4")
+
+[
+  [glib_base, "glib2"],
+  [gobject_introspection_base, "gobject-introspection"],
+  [atk_base, "atk"],
+  [cairo_gobject_base, "cairo-gobject"],
+  [pango_base, "pango"],
+  [gdk_pixbuf_base, "gdk_pixbuf2"],
+  [gio2_base, "gio2"],
+  [gdk4_base, "gdk4"],
+  [gtk4_base, "gtk4"]
+].each do |target, module_name|
+  if File.exist?(File.join(target, "Makefile"))
+    if system("which make > /dev/null")
+      `make -C #{target.dump} > /dev/null` or exit(false)
+    end
+    $LOAD_PATH.unshift(File.join(target, "ext", module_name))
+  end
+  $LOAD_PATH.unshift(File.join(target, "lib"))
+end
+
+# Dir.chdir(File.join(gtk4_base, "test", "fixture")) do
+#   system("rake") or exit(false)
+# end
+
+$LOAD_PATH.unshift(File.join(glib_base, "test"))
+require 'glib-test-init'
+
+$LOAD_PATH.unshift(File.join(gtk4_base, "test"))
+require 'gtk-test-utils'
+
+require 'gtk4'
+
+Gtk.init
+
+exit Test::Unit::AutoRunner.run(true, File.join(gtk4_base, "test"))

--- a/gtk4/test/test-gtk-version.rb
+++ b/gtk4/test/test-gtk-version.rb
@@ -1,0 +1,47 @@
+# Copyright (C) 2015  Ruby-GNOME2 Project Team
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+
+class TestGtkVersion < Test::Unit::TestCase
+  include GtkTestUtils
+
+  test "STRING" do
+    major = Gtk::Version::MAJOR
+    minor = Gtk::Version::MINOR
+    micro = Gtk::Version::MICRO
+    assert_equal([major, minor, micro].join("."),
+                 Gtk::Version::STRING)
+  end
+
+  sub_test_case("#or_later?") do
+    test "same" do
+      assert_true(Gtk::Version.or_later?(Gtk::Version::MAJOR,
+                                         Gtk::Version::MINOR,
+                                         Gtk::Version::MICRO))
+    end
+
+    test "later" do
+      assert_true(Gtk::Version.or_later?(Gtk::Version::MAJOR,
+                                         Gtk::Version::MINOR,
+                                         Gtk::Version::MICRO - 1))
+    end
+
+    test "earlier" do
+      assert_false(Gtk::Version.or_later?(Gtk::Version::MAJOR,
+                                          Gtk::Version::MINOR,
+                                          Gtk::Version::MICRO + 1))
+    end
+  end
+end


### PR DESCRIPTION
I removed most of the Gtk3 related stuff (ext/ ) exept libs in *gtk4/lib/gtk4/* because I will need them latter.

The test for version is working.

@kou,
~~is it possible that we disable the loading of the atom.rb in Gdk4 (and not tests it)? Both the Gtk4 libs from jhbuilder or from my system (ArchLinux) don't implement anymore `GdkAtom`. In order to test both Gtk4 or Gdk4, I have to either comment the line `require "gdk4/atom"` or commit and use a docker instance locally or via Travis which take a lot of resources and or  time.~~

Oups I forgot we already discuss this in #1128 