### PR TITLE
Fixed the checkerboard pattern

### DIFF
--- a/gtk3/sample/gtk-demo/drawingarea.rb
+++ b/gtk3/sample/gtk-demo/drawingarea.rb
@@ -74,7 +74,7 @@ class DrawingareaDemo
       j = spacing
       ycount = xcount % 2 # start with even/odd depending on row
       while j < da.allocated_height
-        if ycount % 2
+        if ycount % 2 == 0
           cr.set_source_rgb(0.45777, 0, 0.45777)
         else
           cr.set_source_rgb(1, 1, 1)
@@ -83,10 +83,10 @@ class DrawingareaDemo
         cr.rectangle(i, j, check_size, check_size)
         cr.fill
         j += check_size + spacing
-        ++ycount
+        ycount += 1
       end
       i += check_size + spacing
-      ++xcount
+      xcount += 1
     end
   end
 


### PR DESCRIPTION
There is no `++` operator in ruby ! 
And 0 and 1 are both evaluated to true:
```rb
puts [0, 1].all? { |v| v}
```