### PR TITLE
gobject-introspection: treat argument of filenames array as C strings…

### DIFF
--- a/gobject-introspection/ext/gobject-introspection/rb-gi-argument.c
+++ b/gobject-introspection/ext/gobject-introspection/rb-gi-argument.c
@@ -267,6 +267,14 @@ array_c_to_ruby_sized(gconstpointer *elements,
         }
         break;
     case GI_TYPE_TAG_FILENAME:
+        g_base_info_unref(element_type_info);
+        {
+            const gchar **strings = (const gchar **)elements;
+            for (i = 0; i < n_elements; i++) {
+                rb_ary_push(rb_array, CSTR2RVAL(strings[i]));
+            }
+        }
+        break;
     case GI_TYPE_TAG_ARRAY:
         g_base_info_unref(element_type_info);
         rb_raise(rb_eNotImpError,
@@ -2281,6 +2289,8 @@ rb_gi_return_argument_free_everything_array_c(GIArgument *argument,
         g_strfreev(argument->v_pointer);
         break;
     case GI_TYPE_TAG_FILENAME:
+        g_strfreev(argument->v_pointer);
+        break;
     case GI_TYPE_TAG_ARRAY:
     case GI_TYPE_TAG_INTERFACE:
     case GI_TYPE_TAG_GLIST:


### PR DESCRIPTION
… array

I had an issue with one of my ruby script that commes from `Gio::ApplicationCommandLine#arguments`. This issue occurs with Gtk 3.22.29 on ArchLinux. 

Here is the output when I test it using the related `Gio` test.
```
==========================================================================================================================================================================================
/home/cedlemo/Projets/Ruby/ruby-gnome2/gio2/test/test-application-command-line.rb:22:in `block in <class:TestApplicationCommandLine>'
/home/cedlemo/Projets/Ruby/ruby-gnome2/gobject-introspection/lib/gobject-introspection/loader.rb:583:in `block in define_method'
/home/cedlemo/Projets/Ruby/ruby-gnome2/gobject-introspection/lib/gobject-introspection/loader.rb:583:in `invoke'
Error: test: #arguments(TestApplicationCommandLine): NotImplementedError: TODO: GIArgument(array)[c][filename] -> Ruby
==========================================================================================================================================================================================

Finished in 0.0017418 seconds.
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
1 tests, 0 assertions, 0 failures, 1 errors, 0 pendings, 0 omissions, 0 notifications
0% passed
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
574.12 tests/s, 0.00 assertions/s
./run-test.rb -t TestApplicationCommandLine  22,37s user 2,64s system 98% cpu 25,379 total
```

https://developer.gnome.org/gio/stable/GApplicationCommandLine.html#g-application-command-line-get-arguments

With this PR, the test passes.