### PR TITLE
gi : fix typo in CSTR2FILENAME2RVAL macro

### DIFF
--- a/gobject-introspection/ext/gobject-introspection/rb-gi-argument.c
+++ b/gobject-introspection/ext/gobject-introspection/rb-gi-argument.c
@@ -272,7 +272,7 @@ array_c_to_ruby_sized(gconstpointer *elements,
         {
             const gchar **filenames = (const gchar **)elements;
             for (i = 0; i < n_elements; i++) {
-                rb_ary_push(rb_array, CSTR2FILENAME2RVAL(filenames[i]));
+                rb_ary_push(rb_array, CSTRFILENAME2RVAL(filenames[i]));
             }
         }
         break;


### PR DESCRIPTION
I just saw that I made a typo in the branch name -_-' , the macro name is `CSTRFILENAME2RVAL`.