### PR TITLE
Gtk4 message dialog

### DIFF
--- a/gtk4/lib/gtk4/loader.rb
+++ b/gtk4/lib/gtk4/loader.rb
@@ -61,6 +61,7 @@ module Gtk
       require "gtk4/button"
       require "gtk4/dialog"
       require "gtk4/menu-item"
+      require "gtk4/message-dialog"
       require "gtk4/version"
       require "gtk4/window"
     end

--- a/gtk4/lib/gtk4/message-dialog.rb
+++ b/gtk4/lib/gtk4/message-dialog.rb
@@ -1,4 +1,4 @@
-# Copyright (C) 2015  Ruby-GNOME2 Project Team
+# Copyright (C) 2015-2018  Ruby-GNOME2 Project Team
 #
 # This library is free software; you can redistribute it and/or
 # modify it under the terms of the GNU Lesser General Public

--- a/gtk4/sample/action-namespace.rb
+++ b/gtk4/sample/action-namespace.rb
@@ -1,0 +1,109 @@
+#!/usr/bin/env ruby
+#
+# Copyright (C) 2018  Ruby-GNOME2 Project Team
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+
+# example from https://github.com/GNOME/gtk/blob/master/examples/action-namespace.c
+
+require_relative "utils"
+
+require_gtk4
+
+MENU_UI =
+"<interface>
+  <menu id='doc-menu'>
+    <section>
+      <item>
+        <attribute name='label'>_Save</attribute>
+        <attribute name='action'>save</attribute>
+      </item>
+      <item>
+        <attribute name='label'>_Print</attribute>
+        <attribute name='action'>print</attribute>
+      </item>
+      <item>
+        <attribute name='label'>_Share</attribute>
+        <attribute name='action'>share</attribute>
+      </item>
+    </section>
+  </menu>
+  <menu id='win-menu'>
+    <section>
+      <item>
+        <attribute name='label'>_Fullscreen</attribute>
+        <attribute name='action'>fullscreen</attribute>
+      </item>
+      <item>
+        <attribute name='label'>_Close</attribute>
+        <attribute name='action'>close</attribute>
+      </item>
+    </section>
+  </menu>
+</interface>"
+
+def action(name, parent)
+  action = Gio::SimpleAction.new(name)
+  action.signal_connect "activate" do |_simple_action, _parameter|
+    dialog = Gtk::Dialog.new(:parent => parent,
+                             :flags => :destroy_with_parent,
+                             :buttons => :close,
+                             :message => "Action #{name} activated.")
+    dialog.show
+  end
+  action
+end
+
+application = Gtk::Application.new("org.gtk.example", :flags_none)
+
+application.signal_connect "activate" do |app|
+  win = Gtk::ApplicationWindow.new(app)
+  win.set_default_size(200, 300)
+  doc_actions = Gio::SimpleActionGroup.new
+  doc_actions.add_action(action("save", win))
+  doc_actions.add_action(action("print", win))
+  doc_actions.add_action(action("share", win))
+  win.insert_action_group("doc_actions", doc_actions)
+
+  win_actions = Gio::SimpleActionGroup.new
+  win_actions.add_action(action("fullscreen", win))
+  win_actions.add_action(action("close", win))
+  win.insert_action_group("win", win_actions)
+
+  builder = Gtk::Builder.new(:string => MENU_UI)
+  docmenu = builder["doc-menu"]
+  winmenu = builder["win-menu"]
+
+  buttonmenu = Gtk::Menu.new
+  section = Gio::MenuItem.new("", :section => docmenu)
+  section.set_attribute("action-namespace", "s", "doc")
+  buttonmenu.append(section)
+
+  section = Gio::MenuItem.new(:section => winmenu)
+  section.set_attribute("action-namespace", "s", "win")
+  buttonmenu.append(section)
+  button = Gtk::MenuButton.new
+  button.label = "Menu"
+  button.insert_action_group("doc", doc_actions)
+  button.model(button_menu)
+  button.halign = :center
+  button.valign = :start
+  win.add(button)
+  win.show
+end
+
+application.run(ARGV)
+
+

--- a/gtk4/test/test-gtk-message-dialog.rb
+++ b/gtk4/test/test-gtk-message-dialog.rb
@@ -1,0 +1,62 @@
+# Copyright (C) 2015-2018  Ruby-GNOME2 Project Team
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+
+class TestGtkMessageDialog < Test::Unit::TestCase
+  include GtkTestUtils
+
+  sub_test_case ".new" do
+    test "no argument" do
+      dialog = Gtk::MessageDialog.new
+      assert_equal("", dialog.text)
+    end
+
+    test "parent" do
+      parent = Gtk::Window.new
+      dialog = Gtk::MessageDialog.new(:parent => parent)
+      assert_equal(parent, dialog.transient_for)
+    end
+
+    test "flags - modal" do
+      dialog = Gtk::MessageDialog.new(:flags => :modal)
+      assert do
+        dialog.modal?
+      end
+    end
+
+    test "flags - destroy_with_parent" do
+      dialog = Gtk::MessageDialog.new(:flags => :destroy_with_parent)
+      assert do
+        dialog.destroy_with_parent?
+      end
+    end
+
+    test "type" do
+      dialog = Gtk::MessageDialog.new(:type => :error)
+      assert_equal(Gtk::MessageType::ERROR, dialog.message_type)
+    end
+
+    test "buttons" do
+      dialog = Gtk::MessageDialog.new(:buttons => :cancel)
+      button = dialog.get_widget_for_response(Gtk::ResponseType::CANCEL)
+      assert_not_nil(button)
+    end
+
+    test "message" do
+      dialog = Gtk::MessageDialog.new(:message => "Label")
+      assert_equal("Label", dialog.text)
+    end
+  end
+end


### PR DESCRIPTION
It seems that this is needed when a new `Gtk::Dialog` is created like in the *action-namespace.rb* demo.

Without this I have the following message:

```
/home/cedlemo/Projects/Ruby/ruby-gnome2/gobject-introspection/lib/gobject-introspection/loader.rb:317:in `invoke': GtkDialog is not subtype of GtkMessageDialog
from /home/cedlemo/Projects/Ruby/ruby-gnome2/gobject-introspection/lib/gobject-introspection/loader.rb:317:in `block (2 levels) in load_constructor_infos'
from /home/cedlemo/Projects/Ruby/ruby-gnome2/gobject-introspection/lib/gobject-introspection/loader.rb:328:in `block in load_constructor_infos'
from /home/cedlemo/Projects/Ruby/ruby-gnome2/gtk4/lib/gtk4/dialog.rb:21:in `initialize'
from ./action-namespace.rb:60:in `new'
from ./action-namespace.rb:60:in `block in action'
from /home/cedlemo/Projects/Ruby/ruby-gnome2/gobject-introspection/lib/gobject-introspection/loader.rb:585:in `invoke'
from /home/cedlemo/Projects/Ruby/ruby-gnome2/gobject-introspection/lib/gobject-introspection/loader.rb:585:in `block in define_method'
from ./action-namespace.rb:130:in `<main>'
./action-namespace.rb: [BUG] Segmentation fault at 0x0000000000000018
ruby 2.4.3p205 (2017-12-14 revision 61247) [x86_64-linux]
```

I hope that you will have some time to explain me why you did this .