### PR TITLE
gtk3 sample: work popover demo with GTK+ 3.18 again

### DIFF
--- a/gtk3/sample/gtk-demo/demo.gresource.xml
+++ b/gtk3/sample/gtk-demo/demo.gresource.xml
@@ -209,6 +209,7 @@
   </gresource>
   <gresource prefix="/popover">
     <file>popover.ui</file>
+    <file>popover-3.18.ui</file>
   </gresource>
   <gresource prefix="/glarea">
     <file>glarea-gl.fs.glsl</file>


### PR DESCRIPTION
Thank you for your update. 
I checked https://github.com/ruby-gnome2/ruby-gnome2/issues/1184 and found it still did not work.
I add popover-3.18.ui to demo.gresource.xml.
Please check it.