### PR TITLE
Gdk pixbuf2 static gem spec

### DIFF
--- a/gdk_pixbuf2/Rakefile
+++ b/gdk_pixbuf2/Rakefile
@@ -22,7 +22,7 @@ require "gnome2/rake/package-task"
 package_name = File.basename(__dir__)
 spec = Gem::Specification.load("#{package_name}.gemspec")
 
-package_task = GNOME2::Rake::PackageTask.new(spec) do |package|
+GNOME2::Rake::PackageTask.define(spec) do |package|
   package.dependency.gem.runtime = [
     "gio2",
   ]
@@ -50,4 +50,3 @@ package_task = GNOME2::Rake::PackageTask.new(spec) do |package|
     }
   ]
 end
-package_task.define

--- a/gdk_pixbuf2/Rakefile
+++ b/gdk_pixbuf2/Rakefile
@@ -19,9 +19,10 @@
 $LOAD_PATH.unshift("./../glib2/lib")
 require "gnome2/rake/package-task"
 
-package_task = GNOME2::Rake::PackageTask.new do |package|
-  package.summary = "Ruby/GdkPixbuf2 is a Ruby binding of GdkPixbuf-2.x."
-  package.description = "Ruby/GdkPixbuf2 is a Ruby binding of GdkPixbuf-2.x."
+package_name = File.basename(__dir__)
+spec = Gem::Specification.load("#{package_name}.gemspec")
+
+package_task = GNOME2::Rake::PackageTask.new(spec) do |package|
   package.dependency.gem.runtime = [
     "gio2",
   ]

--- a/gdk_pixbuf2/gdk_pixbuf2.gemspec
+++ b/gdk_pixbuf2/gdk_pixbuf2.gemspec
@@ -1,0 +1,43 @@
+# -*- ruby -*-
+#
+# Copyright (C) 2018  Ruby-GNOME2 Project Team
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+
+require_relative "../glib2/version"
+
+Gem::Specification.new do |s|
+  s.name          = "gdk_pixbuf2"
+  s.summary       = "Ruby/GdkPixbuf2 is a Ruby binding of GdkPixbuf-2.x."
+  s.description   = "Ruby/GdkPixbuf2 is a Ruby binding of GdkPixbuf-2.x."
+  s.author        = "The Ruby-GNOME2 Project Team"
+  s.email         = "ruby-gnome2-devel-en@lists.sourceforge.net"
+  s.homepage      = "https://ruby-gnome2.osdn.jp/"
+  s.licenses      = ["LGPL-2.1+"]
+  s.version       = ruby_glib2_version
+  s.extensions    = ["ext/#{s.name}/extconf.rb"]
+  s.require_paths = ["lib"]
+  s.files = [
+    "COPYING.LIB",
+    "README.md",
+    "Rakefile",
+    "#{s.name}.gemspec",
+    "extconf.rb",
+    "ext/#{s.name}/depend",
+  ]
+  s.files += Dir.glob("lib/**/*.rb")
+  s.files += Dir.glob("ext/#{s.name}/*.{c,h,def,rb}")
+  s.files += Dir.glob("test/**/*")
+end


### PR DESCRIPTION
I push this so that you can see what I did because I am not able to build the *gdk_pixbuf2* : 

```bash
ruby -S rake gem --trace                                                                     ruby-gnome2/gdk_pixbuf2  gdk_pixbuf2_static_gem_spec
** Invoke gem (first_time)
rake aborted!
Don't know how to build task 'ext/gdk_pixbuf2/depend' (see --tasks)
/home/cedlemo/.gem/ruby/2.5.0/gems/rake-12.3.1/lib/rake/task_manager.rb:59:in `[]'
/home/cedlemo/.gem/ruby/2.5.0/gems/rake-12.3.1/lib/rake/task.rb:62:in `lookup_prerequisite'
/home/cedlemo/.gem/ruby/2.5.0/gems/rake-12.3.1/lib/rake/task.rb:58:in `block in prerequisite_tasks'
/home/cedlemo/.gem/ruby/2.5.0/gems/rake-12.3.1/lib/rake/task.rb:58:in `map'
/home/cedlemo/.gem/ruby/2.5.0/gems/rake-12.3.1/lib/rake/task.rb:58:in `prerequisite_tasks'
/home/cedlemo/.gem/ruby/2.5.0/gems/rake-12.3.1/lib/rake/task.rb:80:in `collect_prerequisites'
/home/cedlemo/.gem/ruby/2.5.0/gems/rake-12.3.1/lib/rake/task.rb:75:in `all_prerequisite_tasks'
/home/cedlemo/.gem/ruby/2.5.0/gems/rake-12.3.1/lib/rake/file_task.rb:33:in `out_of_date?'
/home/cedlemo/.gem/ruby/2.5.0/gems/rake-12.3.1/lib/rake/file_task.rb:17:in `needed?'
/home/cedlemo/.gem/ruby/2.5.0/gems/rake-12.3.1/lib/rake/task.rb:257:in `format_trace_flags'
/home/cedlemo/.gem/ruby/2.5.0/gems/rake-12.3.1/lib/rake/task.rb:196:in `block in invoke_with_call_chain'
/usr/lib/ruby/2.5.0/monitor.rb:226:in `mon_synchronize'
/home/cedlemo/.gem/ruby/2.5.0/gems/rake-12.3.1/lib/rake/task.rb:193:in `invoke_with_call_chain'
/home/cedlemo/.gem/ruby/2.5.0/gems/rake-12.3.1/lib/rake/task.rb:237:in `block in invoke_prerequisites'
/home/cedlemo/.gem/ruby/2.5.0/gems/rake-12.3.1/lib/rake/task.rb:235:in `each'
/home/cedlemo/.gem/ruby/2.5.0/gems/rake-12.3.1/lib/rake/task.rb:235:in `invoke_prerequisites'
/home/cedlemo/.gem/ruby/2.5.0/gems/rake-12.3.1/lib/rake/task.rb:212:in `block in invoke_with_call_chain'
/usr/lib/ruby/2.5.0/monitor.rb:226:in `mon_synchronize'
/home/cedlemo/.gem/ruby/2.5.0/gems/rake-12.3.1/lib/rake/task.rb:193:in `invoke_with_call_chain'
/home/cedlemo/.gem/ruby/2.5.0/gems/rake-12.3.1/lib/rake/task.rb:182:in `invoke'
/home/cedlemo/.gem/ruby/2.5.0/gems/rake-12.3.1/lib/rake/application.rb:160:in `invoke_task'
/home/cedlemo/.gem/ruby/2.5.0/gems/rake-12.3.1/lib/rake/application.rb:116:in `block (2 levels) in top_level'
/home/cedlemo/.gem/ruby/2.5.0/gems/rake-12.3.1/lib/rake/application.rb:116:in `each'
/home/cedlemo/.gem/ruby/2.5.0/gems/rake-12.3.1/lib/rake/application.rb:116:in `block in top_level'
/home/cedlemo/.gem/ruby/2.5.0/gems/rake-12.3.1/lib/rake/application.rb:125:in `run_with_threads'
/home/cedlemo/.gem/ruby/2.5.0/gems/rake-12.3.1/lib/rake/application.rb:110:in `top_level'
/home/cedlemo/.gem/ruby/2.5.0/gems/rake-12.3.1/lib/rake/application.rb:83:in `block in run'
/home/cedlemo/.gem/ruby/2.5.0/gems/rake-12.3.1/lib/rake/application.rb:186:in `standard_exception_handling'
/home/cedlemo/.gem/ruby/2.5.0/gems/rake-12.3.1/lib/rake/application.rb:80:in `run'
/home/cedlemo/.gem/ruby/2.5.0/gems/rake-12.3.1/exe/rake:27:in `<top (required)>'
/home/cedlemo/.gem/ruby/2.5.0/bin/rake:23:in `load'
/home/cedlemo/.gem/ruby/2.5.0/bin/rake:23:in `<main>'
Tasks: TOP => gem => pkg/gdk_pixbuf2-3.2.6.gem
```

I have the same error with `gdk3` while it works well with `pango`.