### PR TITLE
gobject-introspection: Use n_in_args in define_equal_style_setter

### DIFF
--- a/gobject-introspection/lib/gobject-introspection/loader.rb
+++ b/gobject-introspection/lib/gobject-introspection/loader.rb
@@ -596,7 +596,7 @@ module GObjectIntrospection
     end
 
     def define_equal_style_setter(info, klass, method_name)
-      if /\Aset_/ =~ method_name and info.n_args == 1
+      if /\Aset_/ =~ method_name and info.n_in_args == 1
         setter_method_name = "#{$POSTMATCH}="
         remove_existing_method(klass, setter_method_name)
         klass.__send__(:alias_method, setter_method_name, method_name)


### PR DESCRIPTION
Because `n_args` contains arguments of index number of array.

example:

```
/**
 * garrow_orc_file_reader_set_field_indexes:
 * @reader: A #GArrowORCFileReader.
 * @field_indexes: (nullable) (array length=n_field_indexes):
 *   The field indexes to be read.
 * @n_field_indexes: The number of the specified indexes.
 *
 * Since: 0.10.0
 */
void
garrow_orc_file_reader_set_field_indexes(GArrowORCFileReader *reader,
                                         const gint *field_indexes,
                                         guint n_field_indexes)
{
  ....
}
```

`field_indexes` cannot access via `=`.

```
@reader.field_indexes = [1, 3]
`NoMethodError: undefined method `field_indexes=' for #<Arrow::ORCFileReader:0x7faa6d3e5700 ptr=0x7faa6d1d82e0>`
```

This PR fixes it.