### PR TITLE
test-source: Don't assert anything about the idle source's initial name

### DIFF
--- a/glib2/test/test-source.rb
+++ b/glib2/test/test-source.rb
@@ -55,7 +55,6 @@ class TestGLibSource < Test::Unit::TestCase
     only_glib_version(2, 26, 0)
 
     source = GLib::Idle.source_new
-    assert_nil(source.name)
 
     source_name = "glib source"
     source.name = source_name


### PR DESCRIPTION
This is not defined. It was previously empty, but as it happens GLib
2.57.2 started setting default names for its sources. We should instead
test that we can set a name on a source.

See: https://gitlab.gnome.org/GNOME/glib/commit/208a6e815affead7ef8ed86439fcc2bb6a86d56a