### PR TITLE
gobject-introspection: support "free GIArgument(array)[c][gboolean\gint64] everything"

### DIFF
--- a/gobject-introspection/ext/gobject-introspection/rb-gi-argument.c
+++ b/gobject-introspection/ext/gobject-introspection/rb-gi-argument.c
@@ -2365,26 +2365,18 @@ rb_gi_return_argument_free_everything_array_c(GIArgument *argument,
                  g_type_tag_to_string(element_type_tag));
         break;
     case GI_TYPE_TAG_BOOLEAN:
-        g_free(argument->v_pointer);
-        break;
     case GI_TYPE_TAG_INT8:
-        rb_raise(rb_eNotImpError,
-                 "TODO: free GIArgument(array)[c][%s] everything",
-                 g_type_tag_to_string(element_type_tag));
-        break;
     case GI_TYPE_TAG_UINT8:
-        g_free(argument->v_pointer);
-        break;
     case GI_TYPE_TAG_INT16:
     case GI_TYPE_TAG_UINT16:
     case GI_TYPE_TAG_INT32:
     case GI_TYPE_TAG_UINT32:
     case GI_TYPE_TAG_INT64:
-        g_free(argument->v_pointer);
-        break;
     case GI_TYPE_TAG_UINT64:
     case GI_TYPE_TAG_FLOAT:
     case GI_TYPE_TAG_DOUBLE:
+        g_free(argument->v_pointer);
+        break;
     case GI_TYPE_TAG_GTYPE:
         rb_raise(rb_eNotImpError,
                  "TODO: free GIArgument(array)[c][%s] everything",

--- a/gobject-introspection/ext/gobject-introspection/rb-gi-argument.c
+++ b/gobject-introspection/ext/gobject-introspection/rb-gi-argument.c
@@ -2360,6 +2360,10 @@ rb_gi_return_argument_free_everything_array_c(GIArgument *argument,
 
     switch (element_type_tag) {
     case GI_TYPE_TAG_VOID:
+        rb_raise(rb_eNotImpError,
+                 "TODO: free GIArgument(array)[c][%s] everything",
+                 g_type_tag_to_string(element_type_tag));
+        break;
     case GI_TYPE_TAG_BOOLEAN:
         g_free(argument->v_pointer);
         break;

--- a/gobject-introspection/ext/gobject-introspection/rb-gi-argument.c
+++ b/gobject-introspection/ext/gobject-introspection/rb-gi-argument.c
@@ -2361,6 +2361,8 @@ rb_gi_return_argument_free_everything_array_c(GIArgument *argument,
     switch (element_type_tag) {
     case GI_TYPE_TAG_VOID:
     case GI_TYPE_TAG_BOOLEAN:
+        g_free(argument->v_pointer);
+        break;
     case GI_TYPE_TAG_INT8:
         rb_raise(rb_eNotImpError,
                  "TODO: free GIArgument(array)[c][%s] everything",
@@ -2374,6 +2376,8 @@ rb_gi_return_argument_free_everything_array_c(GIArgument *argument,
     case GI_TYPE_TAG_INT32:
     case GI_TYPE_TAG_UINT32:
     case GI_TYPE_TAG_INT64:
+        g_free(argument->v_pointer);
+        break;
     case GI_TYPE_TAG_UINT64:
     case GI_TYPE_TAG_FLOAT:
     case GI_TYPE_TAG_DOUBLE:


### PR DESCRIPTION
For example, free the return value of the following functions.
```cpp
/**
 * garrow_boolean_array_get_values:
 * @array: A #GArrowBooleanArray.
 * @length: (out): The number of values.
 *
 * Returns: (array length=length) (transfer full):
 *   The raw boolean values.
 *
 *   It should be freed with g_free() when no longer needed.
 */
gboolean *
garrow_boolean_array_get_values(GArrowBooleanArray *array,
                                gint64 *length)
{
  auto arrow_array = garrow_array_get_raw(GARROW_ARRAY(array));
  auto arrow_boolean_array =
    std::static_pointer_cast<arrow::BooleanArray>(arrow_array);
  *length = arrow_boolean_array->length();
  auto values = static_cast<gboolean *>(g_new(gboolean, *length));
  for (gint64 i = 0; i < *length; ++i) {
    values[i] = arrow_boolean_array->Value(i);
  }
  return values;
}
```

```cpp
/**
 * garrow_tensor_get_shape:
 * @tensor: A #GArrowTensor.
 * @n_dimensions: (out): The number of dimensions.
 *
 * Returns: (array length=n_dimensions) (transfer full):
 *   The shape of the tensor.
 *
 *   It should be freed with g_free() when no longer needed.
 *
 * Since: 0.3.0
 */
gint64 *
garrow_tensor_get_shape(GArrowTensor *tensor, gint *n_dimensions)
{
  auto arrow_tensor = garrow_tensor_get_raw(tensor);
  auto arrow_shape = arrow_tensor->shape();
  auto n_dimensions_raw = arrow_shape.size();
  auto shape =
    static_cast<gint64 *>(g_malloc_n(sizeof(gint64), n_dimensions_raw));
  for (gsize i = 0; i < n_dimensions_raw; ++i) {
    shape[i] = arrow_shape[i];
  }
  *n_dimensions = static_cast<gint>(n_dimensions_raw);
  return shape;
}
```